### PR TITLE
Added ACI for adobeSign and ServiceNow

### DIFF
--- a/backend/apps/adobe_sign/app.json
+++ b/backend/apps/adobe_sign/app.json
@@ -1,0 +1,30 @@
+{
+    "name": "ADOBE_SIGN",
+    "display_name": "Adobe Acrobat Sign",
+    "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/adobe-sign.svg",
+    "provider": "Adobe",
+    "version": "6.0.0",
+    "description": "The Adobe Acrobat Sign REST API v6 enables access to e-signature workflows including creating and managing agreements, uploading documents, managing templates (library documents), web forms (widgets), sending bulk signatures (MegaSign), managing users and groups, and configuring webhooks. This integration allows sending documents for signature, tracking agreement status, downloading signed documents, and managing the full signing lifecycle on behalf of the user.",
+    "security_schemes": {
+      "oauth2": {
+        "location": "header",
+        "name": "Authorization",
+        "prefix": "Bearer",
+        "prompt": "select_account",
+        "client_id": "{{ AIPOLABS_ADOBE_SIGN_CLIENT_ID }}",
+        "client_secret": "{{ AIPOLABS_ADOBE_SIGN_CLIENT_SECRET }}",
+        "scope": "user_read:self user_write:self user_login:self agreement_read:self agreement_write:self agreement_send:self widget_read:self widget_write:self library_read:self library_write:self workflow_read:self workflow_write:self webhook_read:self webhook_write:self",
+        "authorize_url": "https://secure.{{ AIPOLABS_ADOBE_SIGN_SHARD }}.adobesign.com/public/oauth/v2",
+        "access_token_url": "https://api.{{ AIPOLABS_ADOBE_SIGN_SHARD }}.adobesign.com/oauth/v2/token",
+        "refresh_token_url": "https://api.{{ AIPOLABS_ADOBE_SIGN_SHARD }}.adobesign.com/oauth/v2/refresh"
+      }
+    },
+    "default_security_credentials_by_scheme": {},
+    "categories": [
+      "Productivity",
+      "Document Management",
+      "E-Signature"
+    ],
+    "visibility": "public",
+    "active": true
+  }

--- a/backend/apps/adobe_sign/functions.json
+++ b/backend/apps/adobe_sign/functions.json
@@ -1,0 +1,3789 @@
+[
+    {
+        "name": "ADOBE_SIGN__GET_BASE_URIS",
+        "description": "Retrieve the base URIs (API access point and web access point) for the authenticated user's account. This must be called first to discover the correct shard-specific API endpoint.",
+        "tags": [
+            "base",
+            "configuration"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/baseUris",
+            "server_url": "https://api.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "visible": [],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPLOAD_TRANSIENT_DOCUMENT",
+        "description": "Upload a document to Adobe Sign servers as a transient document. The returned transientDocumentId can be used in agreement, widget, or library document creation calls. Transient documents are automatically deleted after 7 days.",
+        "tags": [
+            "documents",
+            "upload",
+            "transient"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/transientDocuments",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "header": {
+                    "type": "object",
+                    "description": "Request headers",
+                    "properties": {
+                        "Content-Type": {
+                            "type": "string",
+                            "description": "Must be multipart/form-data",
+                            "default": "multipart/form-data"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "Content-Type"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "The multipart form data for the document upload",
+                    "properties": {
+                        "File-Name": {
+                            "type": "string",
+                            "description": "The name of the file being uploaded (e.g., 'Contract.pdf')"
+                        },
+                        "File": {
+                            "type": "string",
+                            "description": "The file content to upload",
+                            "format": "binary"
+                        },
+                        "Mime-Type": {
+                            "type": "string",
+                            "description": "The MIME type of the file (e.g., 'application/pdf')"
+                        }
+                    },
+                    "required": [
+                        "File-Name",
+                        "File"
+                    ],
+                    "visible": [
+                        "File-Name",
+                        "File",
+                        "Mime-Type"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "body"
+            ],
+            "visible": [
+                "header",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__LIST_AGREEMENTS",
+        "description": "Retrieve a paginated list of agreements for the authenticated user. Supports filtering by group and pagination using cursor.",
+        "tags": [
+            "agreements",
+            "list"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/agreements",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters for filtering and pagination",
+                    "properties": {
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor for pagination, returned in previous response"
+                        },
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Number of agreements per page (default 20)"
+                        },
+                        "groupId": {
+                            "type": "string",
+                            "description": "Filter agreements by group ID"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "cursor",
+                        "pageSize",
+                        "groupId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [],
+            "visible": [
+                "query"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__CREATE_AGREEMENT",
+        "description": "Create a new agreement and send it for signature, approval, or save as draft. The agreement can reference transient documents, library documents, or URLs as file sources. State can be IN_PROCESS (send immediately), DRAFT (build incrementally), or AUTHORING (edit form fields).",
+        "tags": [
+            "agreements",
+            "create",
+            "send",
+            "signature"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/agreements",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "object",
+                    "description": "The agreement creation payload",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the agreement"
+                        },
+                        "signatureType": {
+                            "type": "string",
+                            "enum": [
+                                "ESIGN",
+                                "WRITTEN"
+                            ],
+                            "description": "The type of signature: ESIGN (electronic) or WRITTEN (fax/physical)"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "IN_PROCESS",
+                                "DRAFT",
+                                "AUTHORING"
+                            ],
+                            "description": "The initial state of the agreement. IN_PROCESS sends immediately, DRAFT saves for later editing, AUTHORING allows form field editing."
+                        },
+                        "fileInfos": {
+                            "type": "array",
+                            "description": "List of file sources for the agreement",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "transientDocumentId": {
+                                        "type": "string",
+                                        "description": "ID of a transient document uploaded via /transientDocuments"
+                                    },
+                                    "libraryDocumentId": {
+                                        "type": "string",
+                                        "description": "ID of an existing library document template"
+                                    },
+                                    "urlFileInfo": {
+                                        "type": "object",
+                                        "description": "A publicly accessible URL containing the document",
+                                        "properties": {
+                                            "url": {
+                                                "type": "string",
+                                                "description": "The publicly accessible URL of the document"
+                                            },
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The display name for this file"
+                                            },
+                                            "mimeType": {
+                                                "type": "string",
+                                                "description": "MIME type of the document"
+                                            }
+                                        },
+                                        "required": [
+                                            "url"
+                                        ],
+                                        "visible": [
+                                            "url",
+                                            "name",
+                                            "mimeType"
+                                        ],
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "required": [],
+                                "visible": [
+                                    "transientDocumentId",
+                                    "libraryDocumentId",
+                                    "urlFileInfo"
+                                ],
+                                "additionalProperties": false
+                            }
+                        },
+                        "participantSetsInfo": {
+                            "type": "array",
+                            "description": "List of participant sets for the agreement",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "memberInfos": {
+                                        "type": "array",
+                                        "description": "List of members in this participant set",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "email": {
+                                                    "type": "string",
+                                                    "description": "Email address of the participant"
+                                                }
+                                            },
+                                            "required": [
+                                                "email"
+                                            ],
+                                            "visible": [
+                                                "email"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "role": {
+                                        "type": "string",
+                                        "enum": [
+                                            "SIGNER",
+                                            "APPROVER",
+                                            "ACCEPTOR",
+                                            "CERTIFIED_RECIPIENT",
+                                            "FORM_FILLER",
+                                            "DELEGATE_TO_SIGNER",
+                                            "DELEGATE_TO_APPROVER",
+                                            "SHARE"
+                                        ],
+                                        "description": "The role of this participant set"
+                                    },
+                                    "order": {
+                                        "type": "integer",
+                                        "description": "The signing order index for this participant set (starting from 1)"
+                                    }
+                                },
+                                "required": [
+                                    "memberInfos",
+                                    "role",
+                                    "order"
+                                ],
+                                "visible": [
+                                    "memberInfos",
+                                    "role",
+                                    "order"
+                                ],
+                                "additionalProperties": false
+                            }
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "An optional message to the participants"
+                        },
+                        "externalId": {
+                            "type": "object",
+                            "description": "An external identifier for the agreement",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "description": "The unique external ID"
+                                }
+                            },
+                            "required": [
+                                "id"
+                            ],
+                            "visible": [
+                                "id"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "ccs": {
+                            "type": "array",
+                            "description": "CC email addresses that will receive a copy of the agreement",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "description": "Email address for CC"
+                                    }
+                                },
+                                "required": [
+                                    "email"
+                                ],
+                                "visible": [
+                                    "email"
+                                ],
+                                "additionalProperties": false
+                            }
+                        },
+                        "emailOption": {
+                            "type": "object",
+                            "description": "Email notification options",
+                            "properties": {
+                                "sendOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                        "completionEmails": {
+                                            "type": "string",
+                                            "enum": [
+                                                "ALL",
+                                                "NONE"
+                                            ],
+                                            "description": "Send completion emails to ALL or NONE"
+                                        },
+                                        "inFlightEmails": {
+                                            "type": "string",
+                                            "enum": [
+                                                "ALL",
+                                                "NONE"
+                                            ],
+                                            "description": "Send in-flight emails to ALL or NONE"
+                                        },
+                                        "initEmails": {
+                                            "type": "string",
+                                            "enum": [
+                                                "ALL",
+                                                "NONE"
+                                            ],
+                                            "description": "Send initiation emails to ALL or NONE"
+                                        }
+                                    },
+                                    "required": [],
+                                    "visible": [
+                                        "completionEmails",
+                                        "inFlightEmails",
+                                        "initEmails"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [],
+                            "visible": [
+                                "sendOptions"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "signatureType",
+                        "state",
+                        "fileInfos",
+                        "participantSetsInfo"
+                    ],
+                    "visible": [
+                        "name",
+                        "signatureType",
+                        "state",
+                        "fileInfos",
+                        "participantSetsInfo",
+                        "message",
+                        "externalId",
+                        "ccs",
+                        "emailOption"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "body"
+            ],
+            "visible": [
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_AGREEMENT",
+        "description": "Retrieve detailed information about a specific agreement including its status, participants, and metadata.",
+        "tags": [
+            "agreements",
+            "details",
+            "status"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/agreements/{agreementId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPDATE_AGREEMENT",
+        "description": "Update an existing agreement in draft state, or update the expiration time on an agreement that is already out for signature.",
+        "tags": [
+            "agreements",
+            "update"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PUT",
+            "path": "/api/rest/v6/agreements/{agreementId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement to update"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "The agreement update payload",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The updated name of the agreement"
+                        },
+                        "signatureType": {
+                            "type": "string",
+                            "enum": [
+                                "ESIGN",
+                                "WRITTEN"
+                            ],
+                            "description": "The type of signature"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "IN_PROCESS",
+                                "AUTHORING"
+                            ],
+                            "description": "The state to transition the agreement to"
+                        },
+                        "fileInfos": {
+                            "type": "array",
+                            "description": "Updated list of file sources",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "transientDocumentId": {
+                                        "type": "string",
+                                        "description": "ID of a transient document"
+                                    },
+                                    "libraryDocumentId": {
+                                        "type": "string",
+                                        "description": "ID of a library document"
+                                    }
+                                },
+                                "required": [],
+                                "visible": [
+                                    "transientDocumentId",
+                                    "libraryDocumentId"
+                                ],
+                                "additionalProperties": false
+                            }
+                        },
+                        "participantSetsInfo": {
+                            "type": "array",
+                            "description": "Updated participant sets",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "memberInfos": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "email": {
+                                                    "type": "string",
+                                                    "description": "Email of the participant"
+                                                }
+                                            },
+                                            "required": [
+                                                "email"
+                                            ],
+                                            "visible": [
+                                                "email"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of this participant set"
+                                    },
+                                    "order": {
+                                        "type": "integer",
+                                        "description": "Signing order index"
+                                    }
+                                },
+                                "required": [
+                                    "memberInfos",
+                                    "role",
+                                    "order"
+                                ],
+                                "visible": [
+                                    "memberInfos",
+                                    "role",
+                                    "order"
+                                ],
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "signatureType",
+                        "state",
+                        "fileInfos",
+                        "participantSetsInfo"
+                    ],
+                    "visible": [
+                        "name",
+                        "signatureType",
+                        "state",
+                        "fileInfos",
+                        "participantSetsInfo"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPDATE_AGREEMENT_STATE",
+        "description": "Transition an agreement from one state to another, such as cancelling an agreement (IN_PROCESS to CANCELLED).",
+        "tags": [
+            "agreements",
+            "state",
+            "cancel"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PUT",
+            "path": "/api/rest/v6/agreements/{agreementId}/state",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "The state transition payload",
+                    "properties": {
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "CANCELLED"
+                            ],
+                            "description": "The target state for the agreement. Currently only CANCELLED is supported."
+                        },
+                        "agreementCancellationInfo": {
+                            "type": "object",
+                            "description": "Information about the cancellation",
+                            "properties": {
+                                "comment": {
+                                    "type": "string",
+                                    "description": "Reason for cancelling the agreement"
+                                },
+                                "notifyOthers": {
+                                    "type": "boolean",
+                                    "description": "Whether to notify other participants about the cancellation"
+                                }
+                            },
+                            "required": [],
+                            "visible": [
+                                "comment",
+                                "notifyOthers"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [
+                        "state"
+                    ],
+                    "visible": [
+                        "state",
+                        "agreementCancellationInfo"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__DELETE_AGREEMENT",
+        "description": "Delete an agreement. This permanently removes the agreement and its documents. Requires API Retention to be enabled on the account.",
+        "tags": [
+            "agreements",
+            "delete"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "DELETE",
+            "path": "/api/rest/v6/agreements/{agreementId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement to delete"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_AGREEMENT_DOCUMENTS",
+        "description": "Retrieve the IDs of the documents associated with an agreement. These document IDs can then be used to download individual documents.",
+        "tags": [
+            "agreements",
+            "documents",
+            "list"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/agreements/{agreementId}/documents",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                },
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "versionId": {
+                            "type": "string",
+                            "description": "Version of the agreement documents to retrieve. If not specified, the latest version is returned."
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "versionId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path",
+                "query"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_AGREEMENT_COMBINED_DOCUMENT",
+        "description": "Download a single combined PDF document for an agreement, containing all the individual documents concatenated. Optionally includes the audit trail.",
+        "tags": [
+            "agreements",
+            "documents",
+            "download",
+            "combined"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/agreements/{agreementId}/combinedDocument",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                },
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "attachAuditReport": {
+                            "type": "boolean",
+                            "description": "Whether to attach the audit report to the combined document"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "attachAuditReport"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path",
+                "query"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_AGREEMENT_DOCUMENT",
+        "description": "Download a specific individual document from an agreement by its document ID.",
+        "tags": [
+            "agreements",
+            "documents",
+            "download"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/agreements/{agreementId}/documents/{documentId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        },
+                        "documentId": {
+                            "type": "string",
+                            "description": "The unique identifier of the document within the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId",
+                        "documentId"
+                    ],
+                    "visible": [
+                        "agreementId",
+                        "documentId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_AGREEMENT_AUDIT_TRAIL",
+        "description": "Download the audit trail (audit report) PDF for a specific agreement, showing the complete history of actions taken.",
+        "tags": [
+            "agreements",
+            "audit",
+            "download"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/agreements/{agreementId}/auditTrail",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_AGREEMENT_FORM_DATA",
+        "description": "Retrieve the form field data (CSV) that participants entered when signing the agreement.",
+        "tags": [
+            "agreements",
+            "form",
+            "data"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/agreements/{agreementId}/formData",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_AGREEMENT_MEMBERS",
+        "description": "Retrieve information about all the members (participants, sender, sharees) of an agreement.",
+        "tags": [
+            "agreements",
+            "members",
+            "participants"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/agreements/{agreementId}/members",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_AGREEMENT_SIGNING_URLS",
+        "description": "Retrieve the signing URLs for the current signer(s) of an agreement. Only available when the agreement is OUT_FOR_SIGNATURE.",
+        "tags": [
+            "agreements",
+            "signing",
+            "urls"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/agreements/{agreementId}/signingUrls",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__CREATE_AGREEMENT_REMINDER",
+        "description": "Send a signing reminder to the participants of an agreement who have not yet completed their action.",
+        "tags": [
+            "agreements",
+            "reminders",
+            "send"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/agreements/{agreementId}/reminders",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "Reminder configuration",
+                    "properties": {
+                        "recipientParticipantIds": {
+                            "type": "array",
+                            "description": "List of participant IDs to send reminders to. If empty, all participants are reminded.",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "comment": {
+                            "type": "string",
+                            "description": "An optional comment to include in the reminder"
+                        },
+                        "frequency": {
+                            "type": "string",
+                            "enum": [
+                                "ONCE_ONLY",
+                                "DAILY_UNTIL_SIGNED",
+                                "WEEKDAILY_UNTIL_SIGNED",
+                                "EVERY_OTHER_DAY_UNTIL_SIGNED",
+                                "EVERY_THIRD_DAY_UNTIL_SIGNED",
+                                "EVERY_FIFTH_DAY_UNTIL_SIGNED",
+                                "WEEKLY_UNTIL_SIGNED"
+                            ],
+                            "description": "The frequency at which reminders will be sent"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "recipientParticipantIds",
+                        "comment",
+                        "frequency"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_AGREEMENT_VIEWS",
+        "description": "Retrieve views (URLs) associated with an agreement such as the signing page, authoring page, manage page, or documents view.",
+        "tags": [
+            "agreements",
+            "views",
+            "urls"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/agreements/{agreementId}/views",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "View request configuration",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "enum": [
+                                "MANAGE",
+                                "DOCUMENT",
+                                "USER_SIGNING",
+                                "POST_SEND",
+                                "AUTHORING",
+                                "ALL"
+                            ],
+                            "description": "The name of the view to retrieve"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "visible": [
+                        "name"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPDATE_AGREEMENT_VISIBILITY",
+        "description": "Update the visibility of an agreement for the authenticated user. Can be used to hide or show an agreement in the GET /agreements list.",
+        "tags": [
+            "agreements",
+            "visibility",
+            "hide"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PUT",
+            "path": "/api/rest/v6/agreements/{agreementId}/me/visibility",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "Visibility configuration",
+                    "properties": {
+                        "visibility": {
+                            "type": "string",
+                            "enum": [
+                                "SHOW",
+                                "HIDE"
+                            ],
+                            "description": "The desired visibility state"
+                        }
+                    },
+                    "required": [
+                        "visibility"
+                    ],
+                    "visible": [
+                        "visibility"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__SEARCH_AGREEMENTS",
+        "description": "Search for agreement assets using advanced criteria such as date ranges, external IDs, group IDs, and asset types. Returns paginated results.",
+        "tags": [
+            "agreements",
+            "search",
+            "filter"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/search",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "object",
+                    "description": "Search criteria",
+                    "properties": {
+                        "scope": {
+                            "type": "array",
+                            "description": "The scope of the search",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "AGREEMENT_ASSETS"
+                                ]
+                            }
+                        },
+                        "agreementAssetsCriteria": {
+                            "type": "object",
+                            "description": "Criteria for filtering agreement assets",
+                            "properties": {
+                                "type": {
+                                    "type": "array",
+                                    "description": "Filter by asset type",
+                                    "items": {
+                                        "type": "string",
+                                        "enum": [
+                                            "AGREEMENT",
+                                            "WIDGET",
+                                            "MEGASIGN_CHILD",
+                                            "MEGASIGN_PARENT",
+                                            "WIDGET_INSTANCE",
+                                            "LIBRARY_TEMPLATE"
+                                        ]
+                                    }
+                                },
+                                "status": {
+                                    "type": "array",
+                                    "description": "Filter by agreement status",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "createdDate": {
+                                    "type": "object",
+                                    "description": "Filter by creation date range",
+                                    "properties": {
+                                        "range": {
+                                            "type": "object",
+                                            "properties": {
+                                                "gt": {
+                                                    "type": "string",
+                                                    "description": "Greater than date (ISO 8601 format)"
+                                                },
+                                                "lt": {
+                                                    "type": "string",
+                                                    "description": "Less than date (ISO 8601 format)"
+                                                }
+                                            },
+                                            "required": [],
+                                            "visible": [
+                                                "gt",
+                                                "lt"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [],
+                                    "visible": [
+                                        "range"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "modifiedDate": {
+                                    "type": "object",
+                                    "description": "Filter by modification date range",
+                                    "properties": {
+                                        "range": {
+                                            "type": "object",
+                                            "properties": {
+                                                "gt": {
+                                                    "type": "string",
+                                                    "description": "Greater than date (ISO 8601 format)"
+                                                },
+                                                "lt": {
+                                                    "type": "string",
+                                                    "description": "Less than date (ISO 8601 format)"
+                                                }
+                                            },
+                                            "required": [],
+                                            "visible": [
+                                                "gt",
+                                                "lt"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [],
+                                    "visible": [
+                                        "range"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "externalId": {
+                                    "type": "object",
+                                    "description": "Filter by external ID",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": "The external ID to search for"
+                                        }
+                                    },
+                                    "required": [],
+                                    "visible": [
+                                        "id"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "groupId": {
+                                    "type": "string",
+                                    "description": "Filter by group ID"
+                                }
+                            },
+                            "required": [],
+                            "visible": [
+                                "type",
+                                "status",
+                                "createdDate",
+                                "modifiedDate",
+                                "externalId",
+                                "groupId"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Number of results per page"
+                        },
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor for pagination"
+                        }
+                    },
+                    "required": [
+                        "scope"
+                    ],
+                    "visible": [
+                        "scope",
+                        "agreementAssetsCriteria",
+                        "pageSize",
+                        "cursor"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "body"
+            ],
+            "visible": [
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__LIST_LIBRARY_DOCUMENTS",
+        "description": "Retrieve a paginated list of library document templates available to the authenticated user.",
+        "tags": [
+            "library",
+            "templates",
+            "list"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/libraryDocuments",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor for pagination"
+                        },
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Number of items per page"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "cursor",
+                        "pageSize"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [],
+            "visible": [
+                "query"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_LIBRARY_DOCUMENT",
+        "description": "Retrieve detailed information about a specific library document template.",
+        "tags": [
+            "library",
+            "templates",
+            "details"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/libraryDocuments/{libraryDocumentId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "libraryDocumentId": {
+                            "type": "string",
+                            "description": "The unique identifier of the library document"
+                        }
+                    },
+                    "required": [
+                        "libraryDocumentId"
+                    ],
+                    "visible": [
+                        "libraryDocumentId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__CREATE_LIBRARY_DOCUMENT",
+        "description": "Create a new library document template from a transient document. Templates can be reused across multiple agreements.",
+        "tags": [
+            "library",
+            "templates",
+            "create"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/libraryDocuments",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "object",
+                    "description": "Library document creation payload",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the library document template"
+                        },
+                        "sharingMode": {
+                            "type": "string",
+                            "enum": [
+                                "USER",
+                                "GROUP",
+                                "ACCOUNT",
+                                "GLOBAL"
+                            ],
+                            "description": "The visibility/sharing scope of the library document"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "AUTHORING",
+                                "ACTIVE"
+                            ],
+                            "description": "The initial state of the library document"
+                        },
+                        "templateTypes": {
+                            "type": "array",
+                            "description": "The types of templates",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "DOCUMENT",
+                                    "FORM_FIELD_LAYER"
+                                ]
+                            }
+                        },
+                        "fileInfos": {
+                            "type": "array",
+                            "description": "Source files for the library document",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "transientDocumentId": {
+                                        "type": "string",
+                                        "description": "ID of a transient document"
+                                    }
+                                },
+                                "required": [
+                                    "transientDocumentId"
+                                ],
+                                "visible": [
+                                    "transientDocumentId"
+                                ],
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "sharingMode",
+                        "state",
+                        "templateTypes",
+                        "fileInfos"
+                    ],
+                    "visible": [
+                        "name",
+                        "sharingMode",
+                        "state",
+                        "templateTypes",
+                        "fileInfos"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "body"
+            ],
+            "visible": [
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPDATE_LIBRARY_DOCUMENT_STATE",
+        "description": "Transition a library document from one state to another (e.g., AUTHORING to ACTIVE).",
+        "tags": [
+            "library",
+            "templates",
+            "state"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PUT",
+            "path": "/api/rest/v6/libraryDocuments/{libraryDocumentId}/state",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "libraryDocumentId": {
+                            "type": "string",
+                            "description": "The unique identifier of the library document"
+                        }
+                    },
+                    "required": [
+                        "libraryDocumentId"
+                    ],
+                    "visible": [
+                        "libraryDocumentId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "State transition payload",
+                    "properties": {
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "ACTIVE"
+                            ],
+                            "description": "The target state"
+                        }
+                    },
+                    "required": [
+                        "state"
+                    ],
+                    "visible": [
+                        "state"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPDATE_LIBRARY_DOCUMENT_VISIBILITY",
+        "description": "Update the visibility of a library document for the authenticated user (show or hide).",
+        "tags": [
+            "library",
+            "templates",
+            "visibility"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PUT",
+            "path": "/api/rest/v6/libraryDocuments/{libraryDocumentId}/me/visibility",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "libraryDocumentId": {
+                            "type": "string",
+                            "description": "The unique identifier of the library document"
+                        }
+                    },
+                    "required": [
+                        "libraryDocumentId"
+                    ],
+                    "visible": [
+                        "libraryDocumentId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "Visibility configuration",
+                    "properties": {
+                        "visibility": {
+                            "type": "string",
+                            "enum": [
+                                "SHOW",
+                                "HIDE"
+                            ],
+                            "description": "The desired visibility state"
+                        }
+                    },
+                    "required": [
+                        "visibility"
+                    ],
+                    "visible": [
+                        "visibility"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__LIST_WIDGETS",
+        "description": "Retrieve a paginated list of web forms (widgets) for the authenticated user.",
+        "tags": [
+            "widgets",
+            "webforms",
+            "list"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/widgets",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor for pagination"
+                        },
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Number of items per page"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "cursor",
+                        "pageSize"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [],
+            "visible": [
+                "query"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__CREATE_WIDGET",
+        "description": "Create a new web form (widget) that can be embedded or shared via URL. Web forms allow anyone with the link to sign a document.",
+        "tags": [
+            "widgets",
+            "webforms",
+            "create"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/widgets",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "object",
+                    "description": "Widget creation payload",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the web form"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "ACTIVE",
+                                "DRAFT",
+                                "AUTHORING"
+                            ],
+                            "description": "The initial state of the web form"
+                        },
+                        "fileInfos": {
+                            "type": "array",
+                            "description": "Source files for the web form",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "transientDocumentId": {
+                                        "type": "string",
+                                        "description": "ID of a transient document"
+                                    },
+                                    "libraryDocumentId": {
+                                        "type": "string",
+                                        "description": "ID of a library document"
+                                    }
+                                },
+                                "required": [],
+                                "visible": [
+                                    "transientDocumentId",
+                                    "libraryDocumentId"
+                                ],
+                                "additionalProperties": false
+                            }
+                        },
+                        "widgetParticipantSetInfo": {
+                            "type": "object",
+                            "description": "Participant set info for the widget",
+                            "properties": {
+                                "memberInfos": {
+                                    "type": "array",
+                                    "description": "Members of the participant set",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "email": {
+                                                "type": "string",
+                                                "description": "Email of the participant (leave empty for public web forms)"
+                                            }
+                                        },
+                                        "required": [],
+                                        "visible": [
+                                            "email"
+                                        ],
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "role": {
+                                    "type": "string",
+                                    "enum": [
+                                        "SIGNER",
+                                        "APPROVER"
+                                    ],
+                                    "description": "Role of the participant"
+                                }
+                            },
+                            "required": [
+                                "memberInfos",
+                                "role"
+                            ],
+                            "visible": [
+                                "memberInfos",
+                                "role"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "state",
+                        "fileInfos",
+                        "widgetParticipantSetInfo"
+                    ],
+                    "visible": [
+                        "name",
+                        "state",
+                        "fileInfos",
+                        "widgetParticipantSetInfo"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "body"
+            ],
+            "visible": [
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_WIDGET",
+        "description": "Retrieve detailed information about a specific web form (widget).",
+        "tags": [
+            "widgets",
+            "webforms",
+            "details"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/widgets/{widgetId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "widgetId": {
+                            "type": "string",
+                            "description": "The unique identifier of the widget"
+                        }
+                    },
+                    "required": [
+                        "widgetId"
+                    ],
+                    "visible": [
+                        "widgetId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPDATE_WIDGET_STATE",
+        "description": "Transition a widget from one state to another (e.g., ACTIVE to INACTIVE, or DRAFT to CANCELLED).",
+        "tags": [
+            "widgets",
+            "webforms",
+            "state"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PUT",
+            "path": "/api/rest/v6/widgets/{widgetId}/state",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "widgetId": {
+                            "type": "string",
+                            "description": "The unique identifier of the widget"
+                        }
+                    },
+                    "required": [
+                        "widgetId"
+                    ],
+                    "visible": [
+                        "widgetId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "State transition payload",
+                    "properties": {
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "ACTIVE",
+                                "INACTIVE",
+                                "CANCELLED"
+                            ],
+                            "description": "The target state for the widget"
+                        }
+                    },
+                    "required": [
+                        "state"
+                    ],
+                    "visible": [
+                        "state"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_WIDGET_AGREEMENTS",
+        "description": "Retrieve a paginated list of agreements created from a specific web form (widget).",
+        "tags": [
+            "widgets",
+            "webforms",
+            "agreements"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/widgets/{widgetId}/agreements",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "widgetId": {
+                            "type": "string",
+                            "description": "The unique identifier of the widget"
+                        }
+                    },
+                    "required": [
+                        "widgetId"
+                    ],
+                    "visible": [
+                        "widgetId"
+                    ],
+                    "additionalProperties": false
+                },
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor for pagination"
+                        },
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Number of items per page"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "cursor",
+                        "pageSize"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path",
+                "query"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_WIDGET_FORM_DATA",
+        "description": "Retrieve the form field data (CSV) entered by signers of a web form (widget).",
+        "tags": [
+            "widgets",
+            "webforms",
+            "form",
+            "data"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/widgets/{widgetId}/formData",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "widgetId": {
+                            "type": "string",
+                            "description": "The unique identifier of the widget"
+                        }
+                    },
+                    "required": [
+                        "widgetId"
+                    ],
+                    "visible": [
+                        "widgetId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__LIST_MEGASIGNS",
+        "description": "Retrieve a paginated list of MegaSign (bulk send) agreements for the authenticated user.",
+        "tags": [
+            "megasign",
+            "bulk",
+            "list"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/megaSigns",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor for pagination"
+                        },
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Number of items per page"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "cursor",
+                        "pageSize"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [],
+            "visible": [
+                "query"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_MEGASIGN",
+        "description": "Retrieve detailed information about a specific MegaSign (bulk send) agreement.",
+        "tags": [
+            "megasign",
+            "bulk",
+            "details"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/megaSigns/{megaSignId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "megaSignId": {
+                            "type": "string",
+                            "description": "The unique identifier of the MegaSign"
+                        }
+                    },
+                    "required": [
+                        "megaSignId"
+                    ],
+                    "visible": [
+                        "megaSignId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPDATE_MEGASIGN_STATE",
+        "description": "Transition a MegaSign from one state to another (e.g., IN_PROCESS to CANCELLED).",
+        "tags": [
+            "megasign",
+            "bulk",
+            "state",
+            "cancel"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PUT",
+            "path": "/api/rest/v6/megaSigns/{megaSignId}/state",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "megaSignId": {
+                            "type": "string",
+                            "description": "The unique identifier of the MegaSign"
+                        }
+                    },
+                    "required": [
+                        "megaSignId"
+                    ],
+                    "visible": [
+                        "megaSignId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "State transition payload",
+                    "properties": {
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "CANCELLED"
+                            ],
+                            "description": "The target state (CANCELLED)"
+                        }
+                    },
+                    "required": [
+                        "state"
+                    ],
+                    "visible": [
+                        "state"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__LIST_WORKFLOWS",
+        "description": "Retrieve a list of workflows available to the authenticated user.",
+        "tags": [
+            "workflows",
+            "list"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/workflows",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "groupId": {
+                            "type": "string",
+                            "description": "Filter workflows by group ID"
+                        },
+                        "includeDraftWorkflows": {
+                            "type": "boolean",
+                            "description": "Whether to include draft workflows"
+                        },
+                        "includeInactiveWorkflows": {
+                            "type": "boolean",
+                            "description": "Whether to include inactive workflows"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "groupId",
+                        "includeDraftWorkflows",
+                        "includeInactiveWorkflows"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [],
+            "visible": [
+                "query"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_WORKFLOW",
+        "description": "Retrieve detailed information about a specific workflow.",
+        "tags": [
+            "workflows",
+            "details"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/workflows/{workflowId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "workflowId": {
+                            "type": "string",
+                            "description": "The unique identifier of the workflow"
+                        }
+                    },
+                    "required": [
+                        "workflowId"
+                    ],
+                    "visible": [
+                        "workflowId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__LIST_USERS",
+        "description": "Retrieve a paginated list of users in the account. Can filter by admin status.",
+        "tags": [
+            "users",
+            "list",
+            "account"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/users",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor for pagination"
+                        },
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Number of items per page"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "cursor",
+                        "pageSize"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [],
+            "visible": [
+                "query"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_USER",
+        "description": "Retrieve detailed information about a specific user in the account.",
+        "tags": [
+            "users",
+            "details"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/users/{userId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "userId": {
+                            "type": "string",
+                            "description": "The unique identifier of the user"
+                        }
+                    },
+                    "required": [
+                        "userId"
+                    ],
+                    "visible": [
+                        "userId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__CREATE_USER",
+        "description": "Create a new user in the Acrobat Sign account.",
+        "tags": [
+            "users",
+            "create"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/users",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "object",
+                    "description": "User creation payload",
+                    "properties": {
+                        "email": {
+                            "type": "string",
+                            "description": "Email address of the new user"
+                        },
+                        "firstName": {
+                            "type": "string",
+                            "description": "First name of the user"
+                        },
+                        "lastName": {
+                            "type": "string",
+                            "description": "Last name of the user"
+                        },
+                        "company": {
+                            "type": "string",
+                            "description": "Company name"
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Job title"
+                        },
+                        "phone": {
+                            "type": "string",
+                            "description": "Phone number"
+                        }
+                    },
+                    "required": [
+                        "email"
+                    ],
+                    "visible": [
+                        "email",
+                        "firstName",
+                        "lastName",
+                        "company",
+                        "title",
+                        "phone"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "body"
+            ],
+            "visible": [
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPDATE_USER_GROUP",
+        "description": "Migrate a user to a different group or update their role within an existing group.",
+        "tags": [
+            "users",
+            "groups",
+            "update"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PUT",
+            "path": "/api/rest/v6/users/{userId}/groups",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "userId": {
+                            "type": "string",
+                            "description": "The unique identifier of the user"
+                        }
+                    },
+                    "required": [
+                        "userId"
+                    ],
+                    "visible": [
+                        "userId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "Group assignment payload",
+                    "properties": {
+                        "groupInfoList": {
+                            "type": "array",
+                            "description": "List of groups and roles for the user",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The group ID"
+                                    },
+                                    "isGroupAdmin": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is an admin of the group"
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ],
+                                "visible": [
+                                    "id",
+                                    "isGroupAdmin"
+                                ],
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "required": [
+                        "groupInfoList"
+                    ],
+                    "visible": [
+                        "groupInfoList"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__LIST_GROUPS",
+        "description": "Retrieve a paginated list of groups in the account.",
+        "tags": [
+            "groups",
+            "list"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/groups",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor for pagination"
+                        },
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Number of items per page"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "cursor",
+                        "pageSize"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [],
+            "visible": [
+                "query"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_GROUP",
+        "description": "Retrieve detailed information about a specific group.",
+        "tags": [
+            "groups",
+            "details"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/groups/{groupId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "groupId": {
+                            "type": "string",
+                            "description": "The unique identifier of the group"
+                        }
+                    },
+                    "required": [
+                        "groupId"
+                    ],
+                    "visible": [
+                        "groupId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__CREATE_GROUP",
+        "description": "Create a new group in the Acrobat Sign account.",
+        "tags": [
+            "groups",
+            "create"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/groups",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "object",
+                    "description": "Group creation payload",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the group"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "visible": [
+                        "name"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "body"
+            ],
+            "visible": [
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPDATE_GROUP",
+        "description": "Update the name of an existing group.",
+        "tags": [
+            "groups",
+            "update"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PUT",
+            "path": "/api/rest/v6/groups/{groupId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "groupId": {
+                            "type": "string",
+                            "description": "The unique identifier of the group"
+                        }
+                    },
+                    "required": [
+                        "groupId"
+                    ],
+                    "visible": [
+                        "groupId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "Group update payload",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The new name for the group"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "visible": [
+                        "name"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__DELETE_GROUP",
+        "description": "Delete an existing group from the account.",
+        "tags": [
+            "groups",
+            "delete"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "DELETE",
+            "path": "/api/rest/v6/groups/{groupId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "groupId": {
+                            "type": "string",
+                            "description": "The unique identifier of the group to delete"
+                        }
+                    },
+                    "required": [
+                        "groupId"
+                    ],
+                    "visible": [
+                        "groupId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__LIST_WEBHOOKS",
+        "description": "Retrieve a list of webhooks configured for the authenticated user or account.",
+        "tags": [
+            "webhooks",
+            "list"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/webhooks",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "object",
+                    "description": "Query parameters",
+                    "properties": {
+                        "cursor": {
+                            "type": "string",
+                            "description": "Cursor for pagination"
+                        },
+                        "pageSize": {
+                            "type": "integer",
+                            "description": "Number of items per page"
+                        }
+                    },
+                    "required": [],
+                    "visible": [
+                        "cursor",
+                        "pageSize"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [],
+            "visible": [
+                "query"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__CREATE_WEBHOOK",
+        "description": "Create a new webhook to receive real-time notifications when agreement events occur (e.g., signed, cancelled, declined).",
+        "tags": [
+            "webhooks",
+            "create",
+            "notifications"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/webhooks",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "object",
+                    "description": "Webhook creation payload",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the webhook"
+                        },
+                        "scope": {
+                            "type": "string",
+                            "enum": [
+                                "ACCOUNT",
+                                "GROUP",
+                                "USER",
+                                "RESOURCE"
+                            ],
+                            "description": "The scope of events the webhook listens to"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "ACTIVE"
+                            ],
+                            "description": "The initial state of the webhook"
+                        },
+                        "webhookUrlInfo": {
+                            "type": "object",
+                            "description": "The URL to receive webhook notifications",
+                            "properties": {
+                                "url": {
+                                    "type": "string",
+                                    "description": "The HTTPS URL endpoint that will receive webhook POST requests"
+                                }
+                            },
+                            "required": [
+                                "url"
+                            ],
+                            "visible": [
+                                "url"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "webhookSubscriptionEvents": {
+                            "type": "array",
+                            "description": "The events to subscribe to",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "AGREEMENT_ALL",
+                                    "AGREEMENT_CREATED",
+                                    "AGREEMENT_ACTION_COMPLETED",
+                                    "AGREEMENT_ACTION_DELEGATED",
+                                    "AGREEMENT_ACTION_REQUESTED",
+                                    "AGREEMENT_AUTO_CANCELLED_CONVERSION_PROBLEM",
+                                    "AGREEMENT_DOCUMENTS_DELETED",
+                                    "AGREEMENT_EMAIL_BOUNCED",
+                                    "AGREEMENT_EMAIL_VIEWED",
+                                    "AGREEMENT_EXPIRED",
+                                    "AGREEMENT_KBA_AUTHENTICATED",
+                                    "AGREEMENT_MODIFIED",
+                                    "AGREEMENT_OFFLINE_SYNC",
+                                    "AGREEMENT_RECALLED",
+                                    "AGREEMENT_REJECTED",
+                                    "AGREEMENT_SHARED",
+                                    "AGREEMENT_UPLOADED_BY_SENDER",
+                                    "AGREEMENT_VAULTED",
+                                    "AGREEMENT_WEB_IDENTITY_AUTHENTICATED",
+                                    "AGREEMENT_WORKFLOW_COMPLETED",
+                                    "MEGASIGN_ALL",
+                                    "MEGASIGN_CREATED",
+                                    "MEGASIGN_RECALLED",
+                                    "MEGASIGN_SHARED",
+                                    "WIDGET_ALL",
+                                    "WIDGET_CREATED",
+                                    "WIDGET_ENABLED",
+                                    "WIDGET_DISABLED",
+                                    "WIDGET_MODIFIED",
+                                    "WIDGET_SHARED"
+                                ]
+                            }
+                        },
+                        "webhookConditionalParams": {
+                            "type": "object",
+                            "description": "Optional parameters to customize the webhook payload",
+                            "properties": {
+                                "webhookAgreementEvents": {
+                                    "type": "object",
+                                    "properties": {
+                                        "includeDetailedInfo": {
+                                            "type": "boolean",
+                                            "description": "Include detailed agreement info in the payload"
+                                        },
+                                        "includeDocumentsInfo": {
+                                            "type": "boolean",
+                                            "description": "Include document info in the payload"
+                                        },
+                                        "includeParticipantsInfo": {
+                                            "type": "boolean",
+                                            "description": "Include participant info in the payload"
+                                        },
+                                        "includeSignedDocuments": {
+                                            "type": "boolean",
+                                            "description": "Include signed documents (base64) in the payload"
+                                        }
+                                    },
+                                    "required": [],
+                                    "visible": [
+                                        "includeDetailedInfo",
+                                        "includeDocumentsInfo",
+                                        "includeParticipantsInfo",
+                                        "includeSignedDocuments"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [],
+                            "visible": [
+                                "webhookAgreementEvents"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "resourceId": {
+                            "type": "string",
+                            "description": "The ID of the resource (required when scope is RESOURCE)"
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "scope",
+                        "state",
+                        "webhookUrlInfo",
+                        "webhookSubscriptionEvents"
+                    ],
+                    "visible": [
+                        "name",
+                        "scope",
+                        "state",
+                        "webhookUrlInfo",
+                        "webhookSubscriptionEvents",
+                        "webhookConditionalParams",
+                        "resourceId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "body"
+            ],
+            "visible": [
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_WEBHOOK",
+        "description": "Retrieve detailed information about a specific webhook.",
+        "tags": [
+            "webhooks",
+            "details"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/webhooks/{webhookId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "webhookId": {
+                            "type": "string",
+                            "description": "The unique identifier of the webhook"
+                        }
+                    },
+                    "required": [
+                        "webhookId"
+                    ],
+                    "visible": [
+                        "webhookId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPDATE_WEBHOOK",
+        "description": "Update an existing webhook's configuration including name, events, URL, and state.",
+        "tags": [
+            "webhooks",
+            "update"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PUT",
+            "path": "/api/rest/v6/webhooks/{webhookId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "webhookId": {
+                            "type": "string",
+                            "description": "The unique identifier of the webhook"
+                        }
+                    },
+                    "required": [
+                        "webhookId"
+                    ],
+                    "visible": [
+                        "webhookId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "Webhook update payload",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The updated name of the webhook"
+                        },
+                        "scope": {
+                            "type": "string",
+                            "enum": [
+                                "ACCOUNT",
+                                "GROUP",
+                                "USER",
+                                "RESOURCE"
+                            ],
+                            "description": "The scope of events"
+                        },
+                        "state": {
+                            "type": "string",
+                            "enum": [
+                                "ACTIVE",
+                                "INACTIVE"
+                            ],
+                            "description": "The state of the webhook"
+                        },
+                        "webhookUrlInfo": {
+                            "type": "object",
+                            "properties": {
+                                "url": {
+                                    "type": "string",
+                                    "description": "The webhook URL"
+                                }
+                            },
+                            "required": [
+                                "url"
+                            ],
+                            "visible": [
+                                "url"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "webhookSubscriptionEvents": {
+                            "type": "array",
+                            "description": "Updated list of events to subscribe to",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "scope",
+                        "state",
+                        "webhookUrlInfo",
+                        "webhookSubscriptionEvents"
+                    ],
+                    "visible": [
+                        "name",
+                        "scope",
+                        "state",
+                        "webhookUrlInfo",
+                        "webhookSubscriptionEvents"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__DELETE_WEBHOOK",
+        "description": "Delete an existing webhook.",
+        "tags": [
+            "webhooks",
+            "delete"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "DELETE",
+            "path": "/api/rest/v6/webhooks/{webhookId}",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "webhookId": {
+                            "type": "string",
+                            "description": "The unique identifier of the webhook to delete"
+                        }
+                    },
+                    "required": [
+                        "webhookId"
+                    ],
+                    "visible": [
+                        "webhookId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_USER_VIEWS",
+        "description": "Retrieve user-level views such as the manage page, account settings page, or profile page.",
+        "tags": [
+            "users",
+            "views"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/users/{userId}/views",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "userId": {
+                            "type": "string",
+                            "description": "The unique identifier of the user (use 'me' for the authenticated user)"
+                        }
+                    },
+                    "required": [
+                        "userId"
+                    ],
+                    "visible": [
+                        "userId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "View request payload",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "enum": [
+                                "MANAGE",
+                                "ACCOUNT_SETTINGS",
+                                "USER_PROFILE",
+                                "ALL"
+                            ],
+                            "description": "The name of the view to retrieve"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "visible": [
+                        "name"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__DELETE_AGREEMENT_DOCUMENTS",
+        "description": "Delete all documents associated with a specific agreement. Requires API Retention to be enabled.",
+        "tags": [
+            "agreements",
+            "documents",
+            "delete"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "DELETE",
+            "path": "/api/rest/v6/agreements/{agreementId}/documents",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_AGREEMENT_EVENTS",
+        "description": "Retrieve the event history (timeline) for a specific agreement, showing all actions and status changes.",
+        "tags": [
+            "agreements",
+            "events",
+            "history"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/agreements/{agreementId}/events",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__SHARE_AGREEMENT",
+        "description": "Share an agreement with other users, giving them visibility into the agreement.",
+        "tags": [
+            "agreements",
+            "share"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "POST",
+            "path": "/api/rest/v6/agreements/{agreementId}/members/share",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "Share configuration",
+                    "properties": {
+                        "shareeListInfo": {
+                            "type": "array",
+                            "description": "List of users to share the agreement with",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "shareeEmail": {
+                                        "type": "string",
+                                        "description": "Email of the user to share with"
+                                    }
+                                },
+                                "required": [
+                                    "shareeEmail"
+                                ],
+                                "visible": [
+                                    "shareeEmail"
+                                ],
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "required": [
+                        "shareeListInfo"
+                    ],
+                    "visible": [
+                        "shareeListInfo"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__GET_AGREEMENT_NOTES",
+        "description": "Retrieve notes attached to a specific agreement.",
+        "tags": [
+            "agreements",
+            "notes"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/api/rest/v6/agreements/{agreementId}/me/note",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "visible": [
+                "path"
+            ],
+            "additionalProperties": false
+        }
+    },
+    {
+        "name": "ADOBE_SIGN__UPDATE_AGREEMENT_NOTE",
+        "description": "Add or update a note on a specific agreement for the authenticated user.",
+        "tags": [
+            "agreements",
+            "notes",
+            "update"
+        ],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "PUT",
+            "path": "/api/rest/v6/agreements/{agreementId}/me/note",
+            "server_url": "https://api.na1.adobesign.com"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "agreementId": {
+                            "type": "string",
+                            "description": "The unique identifier of the agreement"
+                        }
+                    },
+                    "required": [
+                        "agreementId"
+                    ],
+                    "visible": [
+                        "agreementId"
+                    ],
+                    "additionalProperties": false
+                },
+                "body": {
+                    "type": "object",
+                    "description": "Note content",
+                    "properties": {
+                        "note": {
+                            "type": "string",
+                            "description": "The note text to add or update on the agreement"
+                        }
+                    },
+                    "required": [
+                        "note"
+                    ],
+                    "visible": [
+                        "note"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "path",
+                "body"
+            ],
+            "visible": [
+                "path",
+                "body"
+            ],
+            "additionalProperties": false
+        }
+    }
+]

--- a/backend/apps/service_now/app.json
+++ b/backend/apps/service_now/app.json
@@ -1,0 +1,30 @@
+{
+  "name": "SERVICE_NOW",
+  "display_name": "ServiceNow",
+  "logo": "https://raw.githubusercontent.com/aipotheosis-labs/aipolabs-icons/refs/heads/main/apps/service-now.png",
+  "provider": "ServiceNow",
+  "version": "1.0.0",
+  "description": "The ServiceNow REST API enables access to ITSM modules including Incidents, Change Requests, Problems, Service Requests, CMDB Configuration Items, Users, Knowledge Base Articles, and Tasks. This integration allows agents to read and manage ServiceNow records on behalf of the user.",
+  "security_schemes": {
+    "oauth2": {
+      "location": "header",
+      "name": "Authorization",
+      "prefix": "Bearer",
+      "client_id": "{{ AIPOLABS_SERVICE_NOW_CLIENT_ID }}",
+      "client_secret": "{{ AIPOLABS_SERVICE_NOW_CLIENT_SECRET }}",
+      "scope": "useraccount table_api rest_api_explorer",
+      "authorize_url": "https://wtwdev.service-now.com/oauth_auth.do",
+      "access_token_url": "https://wtwdev.service-now.com/oauth_token.do",
+      "refresh_token_url": "https://wtwdev.service-now.com/oauth_token.do",
+      "prompt": "login"
+    }
+  },
+  "default_security_credentials_by_scheme": {},
+  "categories": [
+    "IT Service Management",
+    "Productivity",
+    "Enterprise"
+  ],
+  "visibility": "public",
+  "active": true
+}

--- a/backend/apps/service_now/functions.json
+++ b/backend/apps/service_now/functions.json
@@ -1,0 +1,2794 @@
+[
+  {
+    "name": "SERVICE_NOW__LIST_INCIDENTS",
+    "description": "Retrieve a list of incidents from ServiceNow with optional filters, sorting, and pagination. Useful for dashboards, reporting, and monitoring open issues.",
+    "tags": [
+      "incidents",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/incident",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Query parameters for filtering, sorting, and paginating incidents.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Encoded query string to filter and sort results. Use '^' as AND operator. Append '^ORDERBYfield' or '^ORDERBYDESCfield' for sorting. e.g., 'state=1^priority=1^ORDERBYDESCopened_at'.",
+              "examples": [
+                "state=1^priority=1^ORDERBYDESCopened_at",
+                "active=true^assigned_to=javascript:gs.getUserID()^ORDERBYopened_at"
+              ]
+            },
+            "sysparm_limit": {
+              "type": "integer",
+              "description": "Maximum number of records to return. Default is 10, max is 10000.",
+              "examples": [
+                10,
+                50,
+                100
+              ]
+            },
+            "sysparm_offset": {
+              "type": "integer",
+              "description": "Starting record index for pagination.",
+              "examples": [
+                0,
+                50,
+                100
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return. Omit to return all fields.",
+              "examples": [
+                "number,short_description,state,priority,assigned_to,opened_at"
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Controls whether to return display values or raw values. Use 'true' for human-readable labels.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_query",
+            "sysparm_limit",
+            "sysparm_offset",
+            "sysparm_fields",
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "visible": [
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__GET_INCIDENT",
+    "description": "Retrieve a single incident record by its sys_id from ServiceNow, including all field details.",
+    "tags": [
+      "incidents",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/incident/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the incident.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the incident record.",
+              "examples": [
+                "1234abcd1234abcd1234abcd1234abcd"
+              ]
+            }
+          },
+          "required": [
+            "sys_id"
+          ],
+          "visible": [
+            "sys_id"
+          ],
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "description": "Optional query parameters.",
+          "properties": {
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "number,short_description,state,priority,assigned_to,opened_at,close_notes"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_display_value",
+            "sysparm_fields"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "visible": [
+        "path",
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__CREATE_INCIDENT",
+    "description": "Create a new incident record in ServiceNow. Used to log new IT issues, outages, or service disruptions.",
+    "tags": [
+      "incidents",
+      "itsm",
+      "create"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "POST",
+      "path": "/api/now/v2/table/incident",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object",
+          "description": "The incident record fields to set on creation.",
+          "properties": {
+            "short_description": {
+              "type": "string",
+              "description": "Brief summary of the incident.",
+              "examples": [
+                "VPN connectivity issue for all remote users"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "description": "Detailed description of the incident.",
+              "examples": [
+                "All users in the London office are unable to connect to the VPN since 09:00 AM GMT."
+              ]
+            },
+            "priority": {
+              "type": "string",
+              "description": "Priority of the incident. 1=Critical, 2=High, 3=Moderate, 4=Low, 5=Planning.",
+              "enum": [
+                "1",
+                "2",
+                "3",
+                "4",
+                "5"
+              ]
+            },
+            "impact": {
+              "type": "string",
+              "description": "Impact level. 1=High, 2=Medium, 3=Low.",
+              "enum": [
+                "1",
+                "2",
+                "3"
+              ]
+            },
+            "urgency": {
+              "type": "string",
+              "description": "Urgency level. 1=High, 2=Medium, 3=Low.",
+              "enum": [
+                "1",
+                "2",
+                "3"
+              ]
+            },
+            "category": {
+              "type": "string",
+              "description": "Incident category (e.g., 'network', 'hardware', 'software', 'inquiry').",
+              "examples": [
+                "network",
+                "software",
+                "hardware"
+              ]
+            },
+            "subcategory": {
+              "type": "string",
+              "description": "Incident subcategory.",
+              "examples": [
+                "vpn",
+                "email",
+                "printer"
+              ]
+            },
+            "assignment_group": {
+              "type": "string",
+              "description": "sys_id or name of the group to assign this incident to.",
+              "examples": [
+                "IT Support",
+                "Network Operations"
+              ]
+            },
+            "assigned_to": {
+              "type": "string",
+              "description": "sys_id or username of the user to assign the incident to.",
+              "examples": [
+                "john.doe"
+              ]
+            },
+            "caller_id": {
+              "type": "string",
+              "description": "sys_id or username of the person who reported the incident.",
+              "examples": [
+                "jane.smith"
+              ]
+            },
+            "cmdb_ci": {
+              "type": "string",
+              "description": "sys_id of the Configuration Item affected by this incident.",
+              "examples": [
+                "prod-web-server-01"
+              ]
+            }
+          },
+          "required": [
+            "short_description"
+          ],
+          "visible": [
+            "short_description",
+            "description",
+            "priority",
+            "impact",
+            "urgency",
+            "category",
+            "subcategory",
+            "assignment_group",
+            "assigned_to",
+            "caller_id",
+            "cmdb_ci"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "body"
+      ],
+      "visible": [
+        "body"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__UPDATE_INCIDENT",
+    "description": "Update an existing incident record in ServiceNow. Used to change state, add notes, reassign, or close an incident.",
+    "tags": [
+      "incidents",
+      "itsm",
+      "update"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "PATCH",
+      "path": "/api/now/v2/table/incident/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the incident.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the incident to update.",
+              "examples": [
+                "1234abcd1234abcd1234abcd1234abcd"
+              ]
+            }
+          },
+          "required": [
+            "sys_id"
+          ],
+          "visible": [
+            "sys_id"
+          ],
+          "additionalProperties": false
+        },
+        "body": {
+          "type": "object",
+          "description": "Fields to update on the incident record.",
+          "properties": {
+            "state": {
+              "type": "string",
+              "description": "Incident state. 1=New, 2=In Progress, 3=On Hold, 4=Resolved, 6=Canceled, 7=Closed.",
+              "enum": [
+                "1",
+                "2",
+                "3",
+                "4",
+                "6",
+                "7"
+              ]
+            },
+            "short_description": {
+              "type": "string",
+              "description": "Updated summary of the incident."
+            },
+            "description": {
+              "type": "string",
+              "description": "Updated detailed description."
+            },
+            "work_notes": {
+              "type": "string",
+              "description": "Internal work notes visible only to agents.",
+              "examples": [
+                "Escalated to network team. Investigating router config."
+              ]
+            },
+            "comments": {
+              "type": "string",
+              "description": "Public comments visible to the caller/customer.",
+              "examples": [
+                "We are actively working on this issue. ETA for resolution is 2 hours."
+              ]
+            },
+            "close_code": {
+              "type": "string",
+              "description": "Resolution code when closing or resolving an incident.",
+              "examples": [
+                "Solved (Permanently)",
+                "Not Solved (Not Reproducible)"
+              ]
+            },
+            "close_notes": {
+              "type": "string",
+              "description": "Resolution notes when closing or resolving the incident.",
+              "examples": [
+                "Restarted the VPN concentrator. All users reconnected successfully."
+              ]
+            },
+            "assigned_to": {
+              "type": "string",
+              "description": "sys_id or username of the user to reassign the incident to."
+            },
+            "assignment_group": {
+              "type": "string",
+              "description": "sys_id or name of the group to reassign this incident to."
+            },
+            "priority": {
+              "type": "string",
+              "description": "Updated priority. 1=Critical, 2=High, 3=Moderate, 4=Low.",
+              "enum": [
+                "1",
+                "2",
+                "3",
+                "4"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "state",
+            "short_description",
+            "description",
+            "work_notes",
+            "comments",
+            "close_code",
+            "close_notes",
+            "assigned_to",
+            "assignment_group",
+            "priority"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path",
+        "body"
+      ],
+      "visible": [
+        "path",
+        "body"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__LIST_CHANGE_REQUESTS",
+    "description": "Retrieve a list of change requests from ServiceNow with optional filters. Used to track planned changes to IT infrastructure and services.",
+    "tags": [
+      "change-management",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/change_request",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Query parameters for filtering and paginating change requests.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Encoded query string to filter change requests. e.g., 'state=assess^type=normal' for normal changes awaiting assessment.",
+              "examples": [
+                "state=assess^type=normal",
+                "type=emergency^active=true"
+              ]
+            },
+            "sysparm_limit": {
+              "type": "integer",
+              "description": "Maximum number of records to return.",
+              "examples": [
+                10,
+                50,
+                100
+              ]
+            },
+            "sysparm_offset": {
+              "type": "integer",
+              "description": "Starting record index for pagination.",
+              "examples": [
+                0,
+                50
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "number,short_description,state,type,risk,start_date,end_date,assignment_group"
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_query",
+            "sysparm_limit",
+            "sysparm_offset",
+            "sysparm_fields",
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "visible": [
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__GET_CHANGE_REQUEST",
+    "description": "Retrieve a single change request record by its sys_id from ServiceNow.",
+    "tags": [
+      "change-management",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/change_request/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the change request.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the change request record.",
+              "examples": [
+                "abcd1234abcd1234abcd1234abcd1234"
+              ]
+            }
+          },
+          "required": [
+            "sys_id"
+          ],
+          "visible": [
+            "sys_id"
+          ],
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "description": "Optional query parameters.",
+          "properties": {
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return."
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_display_value",
+            "sysparm_fields"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "visible": [
+        "path",
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__CREATE_CHANGE_REQUEST",
+    "description": "Create a new change request in ServiceNow. Supports Standard, Normal, and Emergency change types.",
+    "tags": [
+      "change-management",
+      "itsm",
+      "create"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "POST",
+      "path": "/api/now/v2/table/change_request",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object",
+          "description": "The change request record fields to set on creation.",
+          "properties": {
+            "short_description": {
+              "type": "string",
+              "description": "Brief summary of the change.",
+              "examples": [
+                "Upgrade database server from PostgreSQL 14 to 16"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "description": "Detailed description and justification for the change."
+            },
+            "type": {
+              "type": "string",
+              "description": "Type of change request.",
+              "enum": [
+                "standard",
+                "normal",
+                "emergency"
+              ]
+            },
+            "risk": {
+              "type": "string",
+              "description": "Risk level of the change. 1=High, 2=Medium, 3=Low, 4=None.",
+              "enum": [
+                "1",
+                "2",
+                "3",
+                "4"
+              ]
+            },
+            "impact": {
+              "type": "string",
+              "description": "Impact level. 1=High, 2=Medium, 3=Low.",
+              "enum": [
+                "1",
+                "2",
+                "3"
+              ]
+            },
+            "start_date": {
+              "type": "string",
+              "description": "Planned start date/time of the change in format 'YYYY-MM-DD HH:MM:SS'.",
+              "examples": [
+                "2025-06-01 22:00:00"
+              ]
+            },
+            "end_date": {
+              "type": "string",
+              "description": "Planned end date/time of the change in format 'YYYY-MM-DD HH:MM:SS'.",
+              "examples": [
+                "2025-06-02 02:00:00"
+              ]
+            },
+            "assignment_group": {
+              "type": "string",
+              "description": "Name or sys_id of the group responsible for implementing the change.",
+              "examples": [
+                "Database Administration"
+              ]
+            },
+            "assigned_to": {
+              "type": "string",
+              "description": "sys_id or username of the person responsible for implementing the change."
+            },
+            "cmdb_ci": {
+              "type": "string",
+              "description": "sys_id of the Configuration Item being changed.",
+              "examples": [
+                "prod-db-server-01"
+              ]
+            },
+            "justification": {
+              "type": "string",
+              "description": "Business justification for the change.",
+              "examples": [
+                "Required for security compliance. Current version has known CVEs."
+              ]
+            },
+            "implementation_plan": {
+              "type": "string",
+              "description": "Step-by-step plan for implementing the change."
+            },
+            "backout_plan": {
+              "type": "string",
+              "description": "Plan for reverting the change if issues are encountered."
+            },
+            "test_plan": {
+              "type": "string",
+              "description": "Plan for testing the change after implementation."
+            }
+          },
+          "required": [
+            "short_description",
+            "type"
+          ],
+          "visible": [
+            "short_description",
+            "description",
+            "type",
+            "risk",
+            "impact",
+            "start_date",
+            "end_date",
+            "assignment_group",
+            "assigned_to",
+            "cmdb_ci",
+            "justification",
+            "implementation_plan",
+            "backout_plan",
+            "test_plan"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "body"
+      ],
+      "visible": [
+        "body"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__UPDATE_CHANGE_REQUEST",
+    "description": "Update an existing change request in ServiceNow. Used to update state, add implementation notes, or close a change.",
+    "tags": [
+      "change-management",
+      "itsm",
+      "update"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "PATCH",
+      "path": "/api/now/v2/table/change_request/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the change request.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the change request to update."
+            }
+          },
+          "required": [
+            "sys_id"
+          ],
+          "visible": [
+            "sys_id"
+          ],
+          "additionalProperties": false
+        },
+        "body": {
+          "type": "object",
+          "description": "Fields to update on the change request.",
+          "properties": {
+            "state": {
+              "type": "string",
+              "description": "State of the change. -5=New, -4=Assess, -3=Authorize, -2=Scheduled, -1=Implement, 0=Review, 3=Closed, 4=Canceled.",
+              "enum": [
+                "-5",
+                "-4",
+                "-3",
+                "-2",
+                "-1",
+                "0",
+                "3",
+                "4"
+              ]
+            },
+            "work_notes": {
+              "type": "string",
+              "description": "Internal implementation notes.",
+              "examples": [
+                "Database upgrade completed successfully. All services verified."
+              ]
+            },
+            "close_code": {
+              "type": "string",
+              "description": "Close code when closing the change.",
+              "enum": [
+                "successful",
+                "successful_issues",
+                "unsuccessful"
+              ]
+            },
+            "close_notes": {
+              "type": "string",
+              "description": "Notes summarizing the outcome of the change."
+            },
+            "start_date": {
+              "type": "string",
+              "description": "Actual or revised start date in format 'YYYY-MM-DD HH:MM:SS'."
+            },
+            "end_date": {
+              "type": "string",
+              "description": "Actual or revised end date in format 'YYYY-MM-DD HH:MM:SS'."
+            }
+          },
+          "required": [],
+          "visible": [
+            "state",
+            "work_notes",
+            "close_code",
+            "close_notes",
+            "start_date",
+            "end_date"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path",
+        "body"
+      ],
+      "visible": [
+        "path",
+        "body"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__LIST_PROBLEMS",
+    "description": "Retrieve a list of problem records from ServiceNow. Problems represent the root cause of one or more incidents.",
+    "tags": [
+      "problem-management",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/problem",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Query parameters for filtering and paginating problem records.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Encoded query to filter problems.",
+              "examples": [
+                "state=101^known_error=true",
+                "active=true^priority=1"
+              ]
+            },
+            "sysparm_limit": {
+              "type": "integer",
+              "description": "Maximum number of records to return.",
+              "examples": [
+                10,
+                50
+              ]
+            },
+            "sysparm_offset": {
+              "type": "integer",
+              "description": "Starting record index for pagination.",
+              "examples": [
+                0,
+                50
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "number,short_description,state,priority,known_error,workaround,assignment_group"
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_query",
+            "sysparm_limit",
+            "sysparm_offset",
+            "sysparm_fields",
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "visible": [
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__GET_PROBLEM",
+    "description": "Retrieve a single problem record by its sys_id from ServiceNow.",
+    "tags": [
+      "problem-management",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/problem/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the problem record.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the problem record.",
+              "examples": [
+                "abcd5678abcd5678abcd5678abcd5678"
+              ]
+            }
+          },
+          "required": [
+            "sys_id"
+          ],
+          "visible": [
+            "sys_id"
+          ],
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "description": "Optional query parameters.",
+          "properties": {
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "visible": [
+        "path",
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__CREATE_PROBLEM",
+    "description": "Create a new problem record in ServiceNow to track root cause investigation of recurring or major incidents.",
+    "tags": [
+      "problem-management",
+      "itsm",
+      "create"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "POST",
+      "path": "/api/now/v2/table/problem",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object",
+          "description": "Fields for the new problem record.",
+          "properties": {
+            "short_description": {
+              "type": "string",
+              "description": "Brief summary of the problem.",
+              "examples": [
+                "Recurring VPN disconnections for remote workers"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "description": "Detailed description of the problem and its impact."
+            },
+            "priority": {
+              "type": "string",
+              "description": "Priority. 1=Critical, 2=High, 3=Moderate, 4=Low.",
+              "enum": [
+                "1",
+                "2",
+                "3",
+                "4"
+              ]
+            },
+            "assignment_group": {
+              "type": "string",
+              "description": "Name or sys_id of the group assigned to investigate the problem."
+            },
+            "assigned_to": {
+              "type": "string",
+              "description": "sys_id or username of the person assigned to investigate."
+            },
+            "known_error": {
+              "type": "boolean",
+              "description": "Set to true if the root cause has been identified (known error).",
+              "examples": [
+                false
+              ]
+            },
+            "workaround": {
+              "type": "string",
+              "description": "Temporary workaround to mitigate the problem until resolved.",
+              "examples": [
+                "Users should reconnect to the backup VPN endpoint."
+              ]
+            }
+          },
+          "required": [
+            "short_description"
+          ],
+          "visible": [
+            "short_description",
+            "description",
+            "priority",
+            "assignment_group",
+            "assigned_to",
+            "known_error",
+            "workaround"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "body"
+      ],
+      "visible": [
+        "body"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__LIST_SERVICE_REQUESTS",
+    "description": "Retrieve a list of service catalog requests (sc_request) from ServiceNow. Used to track requests submitted through the service catalog.",
+    "tags": [
+      "service-catalog",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/sc_request",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Query parameters for filtering and paginating service requests.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Encoded query string to filter service requests.",
+              "examples": [
+                "state=1^active=true",
+                "requested_for=javascript:gs.getUserID()"
+              ]
+            },
+            "sysparm_limit": {
+              "type": "integer",
+              "description": "Maximum number of records to return.",
+              "examples": [
+                10,
+                50,
+                100
+              ]
+            },
+            "sysparm_offset": {
+              "type": "integer",
+              "description": "Starting record index for pagination.",
+              "examples": [
+                0,
+                50
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "number,short_description,state,requested_for,opened_at"
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_query",
+            "sysparm_limit",
+            "sysparm_offset",
+            "sysparm_fields",
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "visible": [
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__GET_REQUEST_ITEMS",
+    "description": "Retrieve all requested items (RITM - sc_req_item) associated with a service request. Each item represents a catalog item ordered by the user.",
+    "tags": [
+      "service-catalog",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/sc_req_item",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Query parameters for filtering request items.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Encoded query string. Use 'request={request_sys_id}' to filter items for a specific request.",
+              "examples": [
+                "request=abcd1234abcd1234abcd1234abcd1234",
+                "state=1^active=true"
+              ]
+            },
+            "sysparm_limit": {
+              "type": "integer",
+              "description": "Maximum number of records to return.",
+              "examples": [
+                10,
+                50
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "number,short_description,state,cat_item,quantity,assigned_to"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_query",
+            "sysparm_limit",
+            "sysparm_display_value",
+            "sysparm_fields"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "visible": [
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__LIST_CMDB_CIS",
+    "description": "Retrieve configuration items (CIs) from the ServiceNow CMDB. Used to discover and audit IT assets such as servers, applications, and network devices.",
+    "tags": [
+      "cmdb",
+      "assets",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/cmdb_ci",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Query parameters for filtering and paginating CMDB configuration items.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Encoded query to filter CIs.",
+              "examples": [
+                "operational_status=1^sys_class_name=cmdb_ci_server",
+                "name=prod-web-01"
+              ]
+            },
+            "sysparm_limit": {
+              "type": "integer",
+              "description": "Maximum number of records to return.",
+              "examples": [
+                10,
+                50,
+                100
+              ]
+            },
+            "sysparm_offset": {
+              "type": "integer",
+              "description": "Starting record index for pagination.",
+              "examples": [
+                0,
+                50
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "name,sys_class_name,operational_status,ip_address,environment,owned_by"
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_query",
+            "sysparm_limit",
+            "sysparm_offset",
+            "sysparm_fields",
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "visible": [
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__GET_CMDB_CI",
+    "description": "Retrieve a single Configuration Item (CI) from the ServiceNow CMDB by its sys_id.",
+    "tags": [
+      "cmdb",
+      "assets",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/cmdb_ci/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the CI.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the configuration item.",
+              "examples": [
+                "ci1234abcd5678efgh9012ijkl3456mn"
+              ]
+            }
+          },
+          "required": [
+            "sys_id"
+          ],
+          "visible": [
+            "sys_id"
+          ],
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "description": "Optional query parameters.",
+          "properties": {
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return."
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_display_value",
+            "sysparm_fields"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "visible": [
+        "path",
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__LIST_USERS",
+    "description": "Retrieve a list of users from ServiceNow's sys_user table. Used for looking up user accounts, roles, and profile information.",
+    "tags": [
+      "users",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/sys_user",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Query parameters for filtering and paginating users.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Encoded query to filter users.",
+              "examples": [
+                "active=true^department=IT",
+                "email=john.doe@company.com"
+              ]
+            },
+            "sysparm_limit": {
+              "type": "integer",
+              "description": "Maximum number of records to return.",
+              "examples": [
+                10,
+                50
+              ]
+            },
+            "sysparm_offset": {
+              "type": "integer",
+              "description": "Starting record index for pagination.",
+              "examples": [
+                0,
+                50
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "name,email,user_name,department,active,title,manager"
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_query",
+            "sysparm_limit",
+            "sysparm_offset",
+            "sysparm_fields",
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "visible": [
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__GET_USER",
+    "description": "Retrieve a single user record from ServiceNow by sys_id. Used to look up user details such as name, email, department, and manager.",
+    "tags": [
+      "users",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/sys_user/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the user.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the user record.",
+              "examples": [
+                "user1234abcd5678efgh9012ijkl3456"
+              ]
+            }
+          },
+          "required": [
+            "sys_id"
+          ],
+          "visible": [
+            "sys_id"
+          ],
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "description": "Optional query parameters.",
+          "properties": {
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "name,email,user_name,department,active,title,manager,phone"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_display_value",
+            "sysparm_fields"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "visible": [
+        "path",
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__LIST_KNOWLEDGE_ARTICLES",
+    "description": "Retrieve knowledge base articles from ServiceNow. Used to surface self-service documentation, FAQs, and known error workarounds.",
+    "tags": [
+      "knowledge-management",
+      "self-service"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/kb_knowledge",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Query parameters for filtering and paginating knowledge articles.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Encoded query to filter knowledge articles.",
+              "examples": [
+                "workflow_state=published^active=true",
+                "short_description=VPN^workflow_state=published"
+              ]
+            },
+            "sysparm_limit": {
+              "type": "integer",
+              "description": "Maximum number of records to return.",
+              "examples": [
+                10,
+                25,
+                50
+              ]
+            },
+            "sysparm_offset": {
+              "type": "integer",
+              "description": "Starting record index for pagination.",
+              "examples": [
+                0,
+                25
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "number,short_description,text,category,kb_knowledge_base,author,view_count"
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_query",
+            "sysparm_limit",
+            "sysparm_offset",
+            "sysparm_fields",
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "visible": [
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__GET_KNOWLEDGE_ARTICLE",
+    "description": "Retrieve a single knowledge base article from ServiceNow by its sys_id, including full article body content.",
+    "tags": [
+      "knowledge-management",
+      "self-service"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/kb_knowledge/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the knowledge article.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the knowledge article.",
+              "examples": [
+                "kb1234abcd5678efgh9012ijkl3456mn"
+              ]
+            }
+          },
+          "required": [
+            "sys_id"
+          ],
+          "visible": [
+            "sys_id"
+          ],
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "description": "Optional query parameters.",
+          "properties": {
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "number,short_description,text,category,author,workflow_state"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_display_value",
+            "sysparm_fields"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "visible": [
+        "path",
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__SEARCH_KNOWLEDGE_BASE",
+    "description": "Search the ServiceNow Knowledge Base using the full-text search API. Returns relevant articles matching keywords or phrases.",
+    "tags": [
+      "knowledge-management",
+      "search",
+      "self-service"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/kb_knowledge",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Search parameters for the knowledge base.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Encoded query with search terms using CONTAINS or LIKE operators on the short_description or text field.",
+              "examples": [
+                "short_descriptionCONTAINSVPN^workflow_state=published",
+                "textCONTAINSpassword reset^active=true"
+              ]
+            },
+            "sysparm_limit": {
+              "type": "integer",
+              "description": "Maximum number of articles to return.",
+              "examples": [
+                5,
+                10
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "number,short_description,text,category"
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [
+            "sysparm_query"
+          ],
+          "visible": [
+            "sysparm_query",
+            "sysparm_limit",
+            "sysparm_fields",
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "visible": [
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__ADD_COMMENT_TO_RECORD",
+    "description": "Add a public comment or internal work note to any ServiceNow task record (incident, change request, problem, RITM, etc.).",
+    "tags": [
+      "comments",
+      "collaboration",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "PATCH",
+      "path": "/api/now/v2/table/{table_name}/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the target record.",
+          "properties": {
+            "table_name": {
+              "type": "string",
+              "description": "The name of the ServiceNow table containing the record.",
+              "enum": [
+                "incident",
+                "change_request",
+                "problem",
+                "sc_req_item",
+                "task"
+              ]
+            },
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the record to add a comment to.",
+              "examples": [
+                "1234abcd1234abcd1234abcd1234abcd"
+              ]
+            }
+          },
+          "required": [
+            "table_name",
+            "sys_id"
+          ],
+          "visible": [
+            "table_name",
+            "sys_id"
+          ],
+          "additionalProperties": false
+        },
+        "body": {
+          "type": "object",
+          "description": "Comment or work note content to add.",
+          "properties": {
+            "comments": {
+              "type": "string",
+              "description": "Public comment visible to the caller/customer and agents.",
+              "examples": [
+                "We are investigating the issue and will provide an update within 30 minutes."
+              ]
+            },
+            "work_notes": {
+              "type": "string",
+              "description": "Internal work note visible only to agents and not to the end user.",
+              "examples": [
+                "Checked with the network team. The issue is related to a misconfigured firewall rule."
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "comments",
+            "work_notes"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path",
+        "body"
+      ],
+      "visible": [
+        "path",
+        "body"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__QUERY_TABLE",
+    "description": "Generic API to query any ServiceNow table by name. Use this for tables not covered by specific functions, such as custom tables, approvals (sysapproval_approver), or SLAs (task_sla).",
+    "tags": [
+      "generic",
+      "itsm",
+      "table-api"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/v2/table/{table_name}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters specifying the target table.",
+          "properties": {
+            "table_name": {
+              "type": "string",
+              "description": "The name of the ServiceNow table to query.",
+              "examples": [
+                "sysapproval_approver",
+                "task_sla",
+                "sys_journal_field",
+                "cmdb_rel_ci",
+                "sc_catalog_item"
+              ]
+            }
+          },
+          "required": [
+            "table_name"
+          ],
+          "visible": [
+            "table_name"
+          ],
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "description": "Query parameters for filtering, selecting fields, and paginating results.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Encoded query string to filter and sort records. Use '^' as AND operator. Append '^ORDERBYfield' or '^ORDERBYDESCfield' for sorting. e.g., 'active=true^state=requested^ORDERBYDESCsys_created_on'.",
+              "examples": [
+                "active=true^state=requested^ORDERBYDESCsys_created_on",
+                "source_id=1234abcd1234abcd1234abcd1234abcd^ORDERBYnumber"
+              ]
+            },
+            "sysparm_limit": {
+              "type": "integer",
+              "description": "Maximum number of records to return.",
+              "examples": [
+                10,
+                50,
+                100
+              ]
+            },
+            "sysparm_offset": {
+              "type": "integer",
+              "description": "Starting record index for pagination.",
+              "examples": [
+                0,
+                50
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return. Omit to return all fields.",
+              "examples": [
+                "sys_id,number,state,short_description"
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_query",
+            "sysparm_limit",
+            "sysparm_offset",
+            "sysparm_fields",
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "visible": [
+        "path",
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__GET_AGGREGATE_STATS",
+    "description": "Retrieve aggregate statistics (count, sum, avg, min, max) over any ServiceNow table. Useful for reporting, KPIs, and dashboards \u2014 e.g., count of open P1 incidents, average resolution time.",
+    "tags": [
+      "reporting",
+      "analytics",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/stats/{table_name}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters specifying the target table.",
+          "properties": {
+            "table_name": {
+              "type": "string",
+              "description": "The ServiceNow table to aggregate over.",
+              "examples": [
+                "incident",
+                "change_request",
+                "problem",
+                "sc_request"
+              ]
+            }
+          },
+          "required": [
+            "table_name"
+          ],
+          "visible": [
+            "table_name"
+          ],
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "description": "Query parameters for aggregation.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Encoded query to filter records before aggregation.",
+              "examples": [
+                "state=1^priority=1",
+                "active=true^type=normal"
+              ]
+            },
+            "sysparm_count": {
+              "type": "boolean",
+              "description": "Set to true to include a record count in the response.",
+              "examples": [
+                true
+              ]
+            },
+            "sysparm_sum_fields": {
+              "type": "string",
+              "description": "Comma-separated list of numeric fields to sum.",
+              "examples": [
+                "business_duration",
+                "reassignment_count"
+              ]
+            },
+            "sysparm_avg_fields": {
+              "type": "string",
+              "description": "Comma-separated list of numeric fields to average.",
+              "examples": [
+                "business_duration",
+                "reopen_count"
+              ]
+            },
+            "sysparm_min_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to find minimum values for.",
+              "examples": [
+                "opened_at"
+              ]
+            },
+            "sysparm_max_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to find maximum values for.",
+              "examples": [
+                "resolved_at"
+              ]
+            },
+            "sysparm_group_by": {
+              "type": "string",
+              "description": "Field to group aggregated results by.",
+              "examples": [
+                "priority",
+                "state",
+                "assignment_group"
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_query",
+            "sysparm_count",
+            "sysparm_sum_fields",
+            "sysparm_avg_fields",
+            "sysparm_min_fields",
+            "sysparm_max_fields",
+            "sysparm_group_by",
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "visible": [
+        "path",
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__LIST_ATTACHMENTS",
+    "description": "List all attachments linked to a specific ServiceNow record such as an incident, change request, or problem. Returns file name, size, content type, and sys_id for each attachment.",
+    "tags": [
+      "attachments",
+      "files",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/attachment",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Query parameters to filter attachments by record.",
+          "properties": {
+            "sysparm_query": {
+              "type": "string",
+              "description": "Filter attachments by table and record sys_id. e.g., table_name=incident^table_sys_id=1234abcd1234abcd1234abcd1234abcd",
+              "examples": [
+                "table_name=incident^table_sys_id=1234abcd1234abcd1234abcd1234abcd",
+                "table_name=change_request^table_sys_id=abcd1234abcd1234abcd1234abcd1234"
+              ]
+            },
+            "sysparm_limit": {
+              "type": "string",
+              "description": "Maximum number of attachments to return.",
+              "examples": [
+                "10",
+                "50"
+              ]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return.",
+              "examples": [
+                "file_name,size_bytes,content_type,table_name,table_sys_id,sys_id,download_link"
+              ]
+            },
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return display values instead of raw values.",
+              "enum": [
+                "true",
+                "false",
+                "all"
+              ]
+            }
+          },
+          "required": [],
+          "visible": [
+            "sysparm_query",
+            "sysparm_limit",
+            "sysparm_fields",
+            "sysparm_display_value"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "visible": [
+        "query"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__GET_ATTACHMENT_METADATA",
+    "description": "Get metadata of a specific attachment by its sys_id. Returns file name, size, content type, and which record it is attached to. Use LIST_ATTACHMENTS first to find the sys_id.",
+    "tags": [
+      "attachments",
+      "files",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/attachment/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the attachment.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the attachment record.",
+              "examples": [
+                "attach1234abcd5678efgh9012ijkl3456"
+              ]
+            }
+          },
+          "required": [
+            "sys_id"
+          ],
+          "visible": [
+            "sys_id"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "visible": [
+        "path"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__DOWNLOAD_ATTACHMENT",
+    "description": "Download the binary file content of an attachment by its sys_id. Returns the raw file with its original content type such as PDF, PNG, or text. Use GET_ATTACHMENT_METADATA first to find the sys_id.",
+    "tags": [
+      "attachments",
+      "files",
+      "download",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/attachment/{sys_id}/file",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the attachment to download.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the attachment to download.",
+              "examples": [
+                "attach1234abcd5678efgh9012ijkl3456"
+              ]
+            }
+          },
+          "required": [
+            "sys_id"
+          ],
+          "visible": [
+            "sys_id"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "visible": [
+        "path"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__UPLOAD_ATTACHMENT",
+    "description": "Upload a file attachment to any ServiceNow record such as an incident, change request, or problem. Use this to attach error logs, screenshots, or documents directly to a record.",
+    "tags": [
+      "attachments",
+      "files",
+      "upload",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "POST",
+      "path": "/api/now/attachment/file",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Query parameters specifying which record to attach the file to.",
+          "properties": {
+            "table_name": {
+              "type": "string",
+              "description": "The ServiceNow table name of the record to attach the file to.",
+              "examples": [
+                "incident",
+                "change_request",
+                "problem",
+                "sc_req_item",
+                "kb_knowledge"
+              ]
+            },
+            "table_sys_id": {
+              "type": "string",
+              "description": "The sys_id of the specific record to attach the file to.",
+              "examples": [
+                "1234abcd1234abcd1234abcd1234abcd"
+              ]
+            },
+            "file_name": {
+              "type": "string",
+              "description": "The name of the file being uploaded including extension.",
+              "examples": [
+                "error_log.txt",
+                "screenshot.png",
+                "report.pdf"
+              ]
+            },
+            "content_type": {
+              "type": "string",
+              "description": "MIME type of the file being uploaded.",
+              "examples": [
+                "text/plain",
+                "image/png",
+                "application/pdf",
+                "image/jpeg"
+              ]
+            }
+          },
+          "required": [
+            "table_name",
+            "table_sys_id",
+            "file_name",
+            "content_type"
+          ],
+          "visible": [
+            "table_name",
+            "table_sys_id",
+            "file_name",
+            "content_type"
+          ],
+          "additionalProperties": false
+        },
+        "body": {
+          "type": "object",
+          "description": "File content to upload.",
+          "properties": {
+            "content": {
+              "type": "string",
+              "description": "The file content as a base64-encoded string for binary files, or plain text for text files.",
+              "examples": [
+                "SGVsbG8gV29ybGQ=",
+                "Error: connection refused at 10:42 AM"
+              ]
+            }
+          },
+          "required": [
+            "content"
+          ],
+          "visible": [
+            "content"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "query",
+        "body"
+      ],
+      "visible": [
+        "query",
+        "body"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__DELETE_ATTACHMENT",
+    "description": "Permanently delete a specific attachment from a ServiceNow record by its sys_id. Use LIST_ATTACHMENTS first to confirm the correct sys_id before deleting.",
+    "tags": [
+      "attachments",
+      "files",
+      "delete",
+      "itsm"
+    ],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "DELETE",
+      "path": "/api/now/attachment/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the attachment to delete.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the attachment to permanently delete.",
+              "examples": [
+                "attach1234abcd5678efgh9012ijkl3456"
+              ]
+            }
+          },
+          "required": [
+            "sys_id"
+          ],
+          "visible": [
+            "sys_id"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "visible": [
+        "path"
+      ],
+      "additionalProperties": false
+    }
+  },
+  [
+  {
+    "name": "SERVICE_NOW__CREATE_HR_CASE",
+    "description": "Create a new HR case in ServiceNow HR Service Delivery. Used to log HR requests such as onboarding, offboarding, benefits, payroll queries, or employee relations issues.",
+    "tags": ["hr", "cases", "itsm"],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "POST",
+      "path": "/api/now/table/sn_hr_core_case",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "object",
+          "description": "Fields to set on the new HR case record.",
+          "properties": {
+            "short_description": {
+              "type": "string",
+              "description": "Brief summary of the HR case.",
+              "examples": [
+                "Employee relocation request for John Smith",
+                "Benefits enrollment issue for new joiner"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "description": "Detailed description of the HR case and what the employee needs.",
+              "examples": [
+                "Employee John Smith is relocating from London to New York and needs HR support for the transition including visa and tax documentation."
+              ]
+            },
+            "subject_person": {
+              "type": "string",
+              "description": "sys_id or username of the employee this HR case is about.",
+              "examples": ["john.smith", "jane.doe@wtw.com"]
+            },
+            "hr_service": {
+              "type": "string",
+              "description": "sys_id or name of the HR service this case belongs to.",
+              "examples": ["Payroll", "Benefits", "Onboarding", "Offboarding", "Employee Relations"]
+            },
+            "category": {
+              "type": "string",
+              "description": "Category of the HR case.",
+              "examples": ["payroll", "benefits", "leave", "onboarding", "offboarding", "general_inquiry"]
+            },
+            "priority": {
+              "type": "string",
+              "description": "Priority of the HR case. 1=Critical, 2=High, 3=Moderate, 4=Low.",
+              "enum": ["1", "2", "3", "4"]
+            },
+            "assignment_group": {
+              "type": "string",
+              "description": "Name or sys_id of the HR team to assign this case to.",
+              "examples": ["HR Operations", "Benefits Team", "Payroll Team"]
+            },
+            "assigned_to": {
+              "type": "string",
+              "description": "sys_id or username of the HR agent to assign this case to.",
+              "examples": ["hr.agent@wtw.com"]
+            },
+            "opened_for": {
+              "type": "string",
+              "description": "sys_id or username of the employee who the case is opened for.",
+              "examples": ["john.smith@wtw.com"]
+            },
+            "contact_type": {
+              "type": "string",
+              "description": "How the case was submitted.",
+              "enum": ["email", "phone", "self-service", "chat", "walk-in"]
+            }
+          },
+          "required": ["short_description"],
+          "visible": [
+            "short_description",
+            "description",
+            "subject_person",
+            "hr_service",
+            "category",
+            "priority",
+            "assignment_group",
+            "assigned_to",
+            "opened_for",
+            "contact_type"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": ["body"],
+      "visible": ["body"],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__UPDATE_HR_CASE",
+    "description": "Update an existing HR case in ServiceNow. Used to change state, reassign, add comments, or close an HR case.",
+    "tags": ["hr", "cases", "itsm", "update"],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "PATCH",
+      "path": "/api/now/table/sn_hr_core_case/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the HR case.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the HR case to update.",
+              "examples": ["1234abcd1234abcd1234abcd1234abcd"]
+            }
+          },
+          "required": ["sys_id"],
+          "visible": ["sys_id"],
+          "additionalProperties": false
+        },
+        "body": {
+          "type": "object",
+          "description": "Fields to update on the HR case.",
+          "properties": {
+            "state": {
+              "type": "string",
+              "description": "Updated state of the HR case.",
+              "enum": ["1", "2", "3", "4", "5", "6"],
+              "examples": ["1=Draft, 2=Ready, 3=In Progress, 4=Closed Complete, 5=Closed Incomplete, 6=Cancelled"]
+            },
+            "short_description": {
+              "type": "string",
+              "description": "Updated summary of the HR case.",
+              "examples": ["Updated: Employee relocation request for John Smith"]
+            },
+            "description": {
+              "type": "string",
+              "description": "Updated detailed description of the case."
+            },
+            "assignment_group": {
+              "type": "string",
+              "description": "Name or sys_id of the HR team to reassign this case to.",
+              "examples": ["HR Operations", "Benefits Team"]
+            },
+            "assigned_to": {
+              "type": "string",
+              "description": "sys_id or username of the HR agent to reassign to.",
+              "examples": ["hr.agent@wtw.com"]
+            },
+            "comments": {
+              "type": "string",
+              "description": "Public comment visible to the employee.",
+              "examples": ["We have received your request and are processing it. Expected resolution within 3 business days."]
+            },
+            "work_notes": {
+              "type": "string",
+              "description": "Internal work note visible only to HR agents.",
+              "examples": ["Escalated to senior HR advisor. Awaiting approval from line manager."]
+            },
+            "close_notes": {
+              "type": "string",
+              "description": "Resolution notes when closing the case.",
+              "examples": ["Relocation package approved and communicated to employee. Case resolved."]
+            },
+            "priority": {
+              "type": "string",
+              "description": "Updated priority. 1=Critical, 2=High, 3=Moderate, 4=Low.",
+              "enum": ["1", "2", "3", "4"]
+            }
+          },
+          "required": [],
+          "visible": [
+            "state",
+            "short_description",
+            "description",
+            "assignment_group",
+            "assigned_to",
+            "comments",
+            "work_notes",
+            "close_notes",
+            "priority"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": ["path", "body"],
+      "visible": ["path", "body"],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__GET_HR_CASE",
+    "description": "Retrieve full details of a specific HR case by its sys_id including state, subject employee, HR service, assigned team, comments, and work notes.",
+    "tags": ["hr", "cases", "itsm"],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "GET",
+      "path": "/api/now/table/sn_hr_core_case/{sys_id}",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "object",
+          "description": "Path parameters to identify the HR case.",
+          "properties": {
+            "sys_id": {
+              "type": "string",
+              "description": "The unique sys_id of the HR case to retrieve.",
+              "examples": ["1234abcd1234abcd1234abcd1234abcd"]
+            }
+          },
+          "required": ["sys_id"],
+          "visible": ["sys_id"],
+          "additionalProperties": false
+        },
+        "query": {
+          "type": "object",
+          "description": "Optional query parameters.",
+          "properties": {
+            "sysparm_display_value": {
+              "type": "string",
+              "description": "Return human-readable display values instead of raw sys_ids.",
+              "enum": ["true", "false", "all"]
+            },
+            "sysparm_fields": {
+              "type": "string",
+              "description": "Comma-separated list of fields to return. Omit to return all fields.",
+              "examples": [
+                "number,short_description,state,priority,assigned_to,opened_at,subject_person,hr_service"
+              ]
+            }
+          },
+          "required": [],
+          "visible": ["sysparm_display_value", "sysparm_fields"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["path"],
+      "visible": ["path", "query"],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "SERVICE_NOW__ADD_ATTACHMENT_TO_HR_CASE",
+    "description": "Upload and attach a file to an HR case in ServiceNow. Use this to attach supporting documents such as offer letters, medical certificates, payslips, or ID documents to an HR case.",
+    "tags": ["hr", "cases", "attachments", "upload", "itsm"],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "POST",
+      "path": "/api/now/attachment/file",
+      "server_url": "https://wtwdev.service-now.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "Query parameters specifying which HR case to attach the file to.",
+          "properties": {
+            "table_name": {
+              "type": "string",
+              "description": "The ServiceNow table for HR cases. Always use sn_hr_core_case for HR cases.",
+              "enum": ["sn_hr_core_case"]
+            },
+            "table_sys_id": {
+              "type": "string",
+              "description": "The sys_id of the HR case to attach the file to.",
+              "examples": ["1234abcd1234abcd1234abcd1234abcd"]
+            },
+            "file_name": {
+              "type": "string",
+              "description": "The name of the file being uploaded including its extension.",
+              "examples": [
+                "medical_certificate.pdf",
+                "offer_letter.pdf",
+                "payslip_june.pdf",
+                "id_document.png"
+              ]
+            },
+            "content_type": {
+              "type": "string",
+              "description": "MIME type of the file being uploaded.",
+              "examples": [
+                "application/pdf",
+                "image/png",
+                "image/jpeg",
+                "text/plain",
+                "application/msword",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+              ]
+            }
+          },
+          "required": ["table_name", "table_sys_id", "file_name", "content_type"],
+          "visible": ["table_name", "table_sys_id", "file_name", "content_type"],
+          "additionalProperties": false
+        },
+        "body": {
+          "type": "object",
+          "description": "File content to upload.",
+          "properties": {
+            "content": {
+              "type": "string",
+              "description": "The file content as a base64-encoded string for binary files such as PDFs and images, or plain text for text files.",
+              "examples": [
+                "SGVsbG8gV29ybGQ=",
+                "Medical certificate content here..."
+              ]
+            }
+          },
+          "required": ["content"],
+          "visible": ["content"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["query", "body"],
+      "visible": ["query", "body"],
+      "additionalProperties": false
+    }
+  }
+]
+]


### PR DESCRIPTION
### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

Please note this is for WTW workshop requirements - both adobe sign and serviceNow requires specific server urls in functions.json, But variables in functions.json is not supported as on date. So Urls are directly added.

For adobe sign: shardId of "na1" is added.

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
