### PR TITLE
fix: honor app-config prompt in /oauth2 link route

### DIFF
--- a/backend/aci/server/routes/linked_accounts.py
+++ b/backend/aci/server/routes/linked_accounts.py
@@ -630,6 +630,7 @@ async def link_oauth2_account(
         redirect_uri=redirect_uri,
         state=oauth2_state_jwt,
         code_verifier=oauth2_state.code_verifier,
+        prompt=oauth2_scheme.prompt or "consent",
     )
 
     # rewrite the authorization url for some apps that need special handling


### PR DESCRIPTION
The /v1/linked-accounts/oauth2 route was hardcoded to prompt=consent, ignoring the prompt value declared in app.json. The sibling /by-app-id/oauth2 route already passes oauth2_scheme.prompt — match it here so apps configured with prompt=select_account (e.g. SharePoint, Outlook) don't force the consent screen on every sign-in even after tenant-wide admin consent has been granted.