### PR TITLE
updated hard coded model for protocol data

### DIFF
--- a/backend/aci/common/schemas/function.py
+++ b/backend/aci/common/schemas/function.py
@@ -23,6 +23,7 @@ class RestMetadata(BaseModel):
     method: HttpMethod
     path: str
     server_url: str
+    auth_mode: str | None = None
 
 
 class ConnectorMetadata(RootModel[dict]):


### PR DESCRIPTION
Now we can send protocol_data in json as below and it will not be rejected - 

added one field ( auth_mode ) to determine which flow this api supports

( either delegated or application )

  "protocol_data": {
    "method": "GET",
    "path": "/me/messages",
    "server_url": "https://graph.microsoft.com/v1.0",
    "auth_mode" : "delegated"
  }