### PR TITLE
Enhance app deletion process and error handling

### DIFF
--- a/backend/aci/common/db/crud/apps.py
+++ b/backend/aci/common/db/crud/apps.py
@@ -5,10 +5,10 @@ CRUD operations for apps. (not including app_configurations)
 import os
 from uuid import UUID
 
-from sqlalchemy import select, update, or_
+from sqlalchemy import delete as sql_delete, select, update, or_
 from sqlalchemy.orm import Session
 
-from aci.common.db.sql_models import App
+from aci.common.db.sql_models import App, AppConfiguration, LinkedAccount
 from aci.common.enums import SecurityScheme, Visibility
 from aci.common.logging_setup import get_logger
 from aci.common.schemas.app import AppUpsert
@@ -211,17 +211,38 @@ def delete_app_by_id(
     app_id: UUID,
     api_key_id: UUID,
 ) -> bool:
-    """Delete an app if it was created by the given API key."""
+    """Delete an app if it was created by the given API key.
+
+    Explicitly removes AppConfiguration and LinkedAccount rows that reference
+    this app before deleting the app itself, because App has no ORM cascade to
+    those tables and Postgres FK constraints would otherwise reject the DELETE.
+    """
     try:
         app = db_session.execute(
             select(App).filter(App.id == app_id, App.api_key_id == api_key_id)
         ).scalar_one_or_none()
 
-        if app:
-            db_session.delete(app)
-            db_session.flush()
-            return True
-        return False
+        if not app:
+            return False
+
+        # Delete dependents with synchronize_session=False to bypass identity-map
+        # evaluation, then flush immediately so the rows are gone in the DB before
+        # we attempt to DELETE the app row (which has no ORM cascade to these tables).
+        db_session.execute(
+            sql_delete(LinkedAccount)
+            .where(LinkedAccount.app_id == app_id)
+            .execution_options(synchronize_session=False)
+        )
+        db_session.execute(
+            sql_delete(AppConfiguration)
+            .where(AppConfiguration.app_id == app_id)
+            .execution_options(synchronize_session=False)
+        )
+        db_session.flush()
+
+        db_session.delete(app)
+        db_session.flush()
+        return True
     except Exception as e:
         if "column apps.api_key_id does not exist" in str(e):
             logger.warning("api_key_id column does not exist yet in apps table. Cannot delete app.")

--- a/backend/aci/server/routes/tool_seeding.py
+++ b/backend/aci/server/routes/tool_seeding.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any, Dict, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from sqlalchemy.orm import Session
 
 from aci.cli.commands import upsert_app, upsert_functions
@@ -516,6 +516,18 @@ async def upsert_app_from_json(
             if secrets_file_path and secrets_file_path.exists():
                 secrets_file_path.unlink()
 
+    except ValidationError as e:
+        lines = []
+        for err in e.errors():
+            loc = err["loc"]
+            field = " → ".join(str(l) for l in loc) if loc else "(root)"
+            lines.append(f"App JSON · {field}: {err['msg']}")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="\n".join(lines),
+        )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error upserting app from JSON content: {str(e)}")
         raise HTTPException(
@@ -573,6 +585,23 @@ async def upsert_functions_from_json(
             if functions_file_path.exists():
                 functions_file_path.unlink()
 
+    except ValidationError as e:
+        lines = []
+        for err in e.errors():
+            loc = err["loc"]
+            if loc and isinstance(loc[0], int):
+                item_label = f"item #{loc[0] + 1}"
+                field = " → ".join(str(l) for l in loc[1:]) if len(loc) > 1 else "(root)"
+                lines.append(f"Function JSON · {item_label} · {field}: {err['msg']}")
+            else:
+                field = " → ".join(str(l) for l in loc) if loc else "(root)"
+                lines.append(f"Function JSON · {field}: {err['msg']}")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="\n".join(lines),
+        )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error upserting functions from JSON content: {str(e)}")
         raise HTTPException(
@@ -738,11 +767,11 @@ async def delete_my_custom_app_by_id(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error deleting custom app {app_id}: {str(e)}")
+        logger.error(f"Error deleting custom app {app_id}: {str(e)}", exc_info=True)
         context.db_session.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to delete app: {str(e)}"
+            detail=f"Error deleting custom app {app_id}: {str(e)}"
         )
 
 


### PR DESCRIPTION
- Updated the delete_app_by_id function to explicitly remove related AppConfiguration and LinkedAccount entries before deleting the app, addressing foreign key constraints.
- Improved error handling in upsert_app_from_json and upsert_functions_from_json to provide more detailed validation error messages.
- Enhanced logging for errors during app deletion to include exception information.

### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

[Describe your changes in detail (optional if the issue you linked already contains a
detail description of the change)]

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
