### PR TITLE
fix: replace uvicorn ProxyHeadersMiddleware with CIDR-aware custom mi…

### DIFF
--- a/backend/aci/server/config.py
+++ b/backend/aci/server/config.py
@@ -1,3 +1,5 @@
+import os
+
 from aci.common.utils import check_and_get_env_variable, construct_db_url
 
 ENVIRONMENT = check_and_get_env_variable("SERVER_ENVIRONMENT")
@@ -42,7 +44,17 @@ RATE_LIMIT_IP_PER_DAY = int(check_and_get_env_variable("SERVER_RATE_LIMIT_IP_PER
 # QUOTA
 PROJECT_DAILY_QUOTA = int(check_and_get_env_variable("SERVER_PROJECT_DAILY_QUOTA"))
 MAX_AGENTS_PER_PROJECT = int(check_and_get_env_variable("SERVER_MAX_AGENTS_PER_PROJECT"))
-APPLICATION_LOAD_BALANCER_DNS = check_and_get_env_variable("SERVER_APPLICATION_LOAD_BALANCER_DNS")
+# Trusted upstream proxy IPs/hostnames/CIDRs for ProxyHeadersMiddleware.
+# Accepts a comma-separated list of exact IPs, hostnames, or CIDR ranges.
+# AWS ALB:          set to the ALB DNS name or IP
+# Azure App GW:     set to the App Gateway subnet CIDR (e.g. "10.200.0.0/24")
+# Falls back to the legacy SERVER_APPLICATION_LOAD_BALANCER_DNS var if set.
+# Defaults to "*" (trust all) when unset — safe behind a private-subnet proxy.
+TRUSTED_PROXY_HOSTS: str = (
+    os.getenv("SERVER_TRUSTED_PROXY_HOSTS")
+    or os.getenv("SERVER_APPLICATION_LOAD_BALANCER_DNS")
+    or "*"
+)
 OAUTH2_CLIENT_CREDENTIALS_FALLBACK_TTL_SECONDS = int(
         check_and_get_env_variable("CLIENT_CREDENTIALS_FALLBACK_TTL_SECONDS")
     )

--- a/backend/aci/server/main.py
+++ b/backend/aci/server/main.py
@@ -8,7 +8,7 @@ from fastapi.routing import APIRoute
 from pythonjsonlogger.json import JsonFormatter
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
-from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+from aci.server.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from aci.common.exceptions import ACIException
 from aci.common.logging_setup import setup_logging
@@ -130,7 +130,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.add_middleware(InterceptorMiddleware)
-app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=[config.APPLICATION_LOAD_BALANCER_DNS])
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=config.TRUSTED_PROXY_HOSTS)
 
 
 # NOTE: generic exception handler (type Exception) for all exceptions doesn't work

--- a/backend/aci/server/middleware/proxy_headers.py
+++ b/backend/aci/server/middleware/proxy_headers.py
@@ -1,0 +1,68 @@
+import ipaddress
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class ProxyHeadersMiddleware:
+    """
+    Rewrites scope["client"] and scope["scheme"] from X-Forwarded-For /
+    X-Forwarded-Proto headers, but only when the connecting IP is trusted.
+
+    trusted_hosts accepts:
+    - "*"                  – trust every proxy (safe when the pod is already
+                             in a private subnet behind an ALB / App Gateway)
+    - exact IP or hostname – e.g. "my-alb.us-east-1.elb.amazonaws.com"
+    - CIDR range           – e.g. "10.200.0.0/24" (Azure App Gateway subnet)
+    - comma-separated mix  – e.g. "10.200.0.0/24,10.0.0.5"
+
+    For AWS ALB set SERVER_TRUSTED_PROXY_HOSTS to the ALB DNS name or IP.
+    For Azure App Gateway set it to the App Gateway subnet CIDR.
+    Leave it unset (or "*") to trust all proxies.
+    """
+
+    def __init__(self, app: ASGIApp, trusted_hosts: str | list[str] = "*") -> None:
+        self.app = app
+        self._trust_all = trusted_hosts == "*"
+        self._cidr_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+        self._exact_hosts: set[str] = set()
+
+        if not self._trust_all:
+            if isinstance(trusted_hosts, str):
+                hosts = [h.strip() for h in trusted_hosts.split(",") if h.strip()]
+            else:
+                hosts = [h.strip() for h in trusted_hosts if h.strip()]
+
+            for host in hosts:
+                try:
+                    self._cidr_networks.append(ipaddress.ip_network(host, strict=False))
+                except ValueError:
+                    self._exact_hosts.add(host)
+
+    def _is_trusted(self, host: str) -> bool:
+        if self._trust_all:
+            return True
+        if host in self._exact_hosts:
+            return True
+        try:
+            ip = ipaddress.ip_address(host)
+            return any(ip in net for net in self._cidr_networks)
+        except ValueError:
+            return False
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] in ("http", "websocket"):
+            client = scope.get("client")
+            if client and self._is_trusted(client[0]):
+                headers = dict(scope["headers"])
+
+                if b"x-forwarded-for" in headers:
+                    # Leftmost entry is the original client IP
+                    forwarded_for = headers[b"x-forwarded-for"].decode("latin-1")
+                    client_host = forwarded_for.split(",")[0].strip()
+                    scope["client"] = (client_host, 0)
+
+                if b"x-forwarded-proto" in headers:
+                    proto = headers[b"x-forwarded-proto"].decode("latin-1")
+                    scope["scheme"] = proto.split(",")[0].strip()
+
+        await self.app(scope, receive, send)


### PR DESCRIPTION
…ddleware

Fixes startup crash when SERVER_APPLICATION_LOAD_BALANCER_DNS is not set. The new middleware supports exact IPs/hostnames and CIDR ranges (e.g. 10.200.0.0/24 for Azure App Gateway subnets with dynamic IPs), and accepts a comma-separated list for multi-cloud deployments.

SERVER_TRUSTED_PROXY_HOSTS is the new env var; falls back to the legacy SERVER_APPLICATION_LOAD_BALANCER_DNS for backward compatibility. Defaults to "*" when neither is set (safe behind a private-subnet proxy/ALB).

### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

[Describe your changes in detail (optional if the issue you linked already contains a
detail description of the change)]

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
