### PR TITLE
feat: add Azure Key Vault encryption alongside AWS KMS

### DIFF
--- a/backend/aci/common/config.py
+++ b/backend/aci/common/config.py
@@ -1,9 +1,24 @@
 import os
+
 from aci.common.utils import check_and_get_env_variable
 
-AWS_REGION = check_and_get_env_variable("COMMON_AWS_REGION")
-# AWS_ENDPOINT_URL can be empty for production (uses default AWS endpoints)
-# Only set this for LocalStack or custom endpoints
-AWS_ENDPOINT_URL = os.getenv("COMMON_AWS_ENDPOINT_URL") or None
-KEY_ENCRYPTION_KEY_ARN = check_and_get_env_variable("COMMON_KEY_ENCRYPTION_KEY_ARN")
+# Azure Key Vault config — when set, takes precedence over AWS KMS for encryption.
+# AZURE_KEY_ENCRYPTION_KEY_NAME: name of the key in the vault (e.g. "aci-encryption-key")
+# AZURE_KEY_VAULT_URL: vault endpoint (e.g. "https://my-vault.vault.azure.net/")
+AZURE_KEY_ENCRYPTION_KEY_NAME = os.getenv("AZURE_KEY_ENCRYPTION_KEY_NAME")
+AZURE_KEY_VAULT_URL = os.getenv("AZURE_KEY_VAULT_URL")
+
+# AWS KMS config — required when Azure Key Vault is not configured.
+# When Azure mode is active these vars are optional (os.getenv), otherwise they are required.
+if AZURE_KEY_ENCRYPTION_KEY_NAME:
+    AWS_REGION = os.getenv("COMMON_AWS_REGION") or None
+    AWS_ENDPOINT_URL = os.getenv("COMMON_AWS_ENDPOINT_URL") or None
+    KEY_ENCRYPTION_KEY_ARN = os.getenv("COMMON_KEY_ENCRYPTION_KEY_ARN") or None
+else:
+    AWS_REGION = check_and_get_env_variable("COMMON_AWS_REGION")
+    # AWS_ENDPOINT_URL can be empty for production (uses default AWS endpoints)
+    # Only set this for LocalStack or custom endpoints
+    AWS_ENDPOINT_URL = os.getenv("COMMON_AWS_ENDPOINT_URL") or None
+    KEY_ENCRYPTION_KEY_ARN = check_and_get_env_variable("COMMON_KEY_ENCRYPTION_KEY_ARN")
+
 API_KEY_HASHING_SECRET = check_and_get_env_variable("COMMON_API_KEY_HASHING_SECRET")

--- a/backend/aci/common/encryption.py
+++ b/backend/aci/common/encryption.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import os
+import struct
 from typing import cast
 
 import aws_encryption_sdk  # type: ignore
@@ -19,8 +20,9 @@ client = aws_encryption_sdk.EncryptionSDKClient(
     commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
 )
 
-# Lazy initialization of KMS resources
+# Lazy initialization of KMS / Azure Key Vault resources
 _kms_keyring: IKeyring | None = None
+_azure_crypto_client: object | None = None
 
 
 def _get_kms_keyring() -> IKeyring:
@@ -46,10 +48,70 @@ def _get_kms_keyring() -> IKeyring:
     return _kms_keyring
 
 
+def _get_azure_crypto_client() -> object:
+    """Lazy initialization of Azure Key Vault CryptographyClient."""
+    global _azure_crypto_client
+    if _azure_crypto_client is None:
+        from azure.identity import DefaultAzureCredential  # type: ignore
+        from azure.keyvault.keys import KeyClient  # type: ignore
+        from azure.keyvault.keys.crypto import CryptographyClient  # type: ignore
+
+        credential = DefaultAzureCredential()
+        key_client = KeyClient(vault_url=config.AZURE_KEY_VAULT_URL, credential=credential)
+        key = key_client.get_key(config.AZURE_KEY_ENCRYPTION_KEY_NAME)
+        _azure_crypto_client = CryptographyClient(key, credential=credential)
+    return _azure_crypto_client
+
+
+def _azure_encrypt(plain_data: bytes) -> bytes:
+    """Envelope encryption: AES-256-GCM for data, Azure Key Vault RSA-OAEP-256 for DEK wrapping.
+
+    Wire format: [4-byte big-endian wrapped_dek_len][wrapped_dek][12-byte nonce][GCM ciphertext+tag]
+    """
+    import secrets
+
+    from azure.keyvault.keys.crypto import CryptographyClient  # type: ignore
+    from azure.keyvault.keys.crypto import KeyWrapAlgorithm  # type: ignore
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # type: ignore
+
+    dek = secrets.token_bytes(32)  # 256-bit data encryption key
+    nonce = secrets.token_bytes(12)  # 96-bit GCM nonce
+    ciphertext = AESGCM(dek).encrypt(nonce, plain_data, None)
+
+    crypto_client = cast(CryptographyClient, _get_azure_crypto_client())
+    wrapped_dek = crypto_client.wrap_key(KeyWrapAlgorithm.rsa_oaep_256, dek).encrypted_key
+
+    return struct.pack(">I", len(wrapped_dek)) + wrapped_dek + nonce + ciphertext
+
+
+def _azure_decrypt(cipher_data: bytes) -> bytes:
+    """Envelope decryption: unwrap DEK via Azure Key Vault, then AES-256-GCM decrypt."""
+    from azure.keyvault.keys.crypto import CryptographyClient  # type: ignore
+    from azure.keyvault.keys.crypto import KeyWrapAlgorithm  # type: ignore
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # type: ignore
+
+    offset = 0
+    (wrapped_dek_len,) = struct.unpack_from(">I", cipher_data, offset)
+    offset += 4
+    wrapped_dek = cipher_data[offset : offset + wrapped_dek_len]
+    offset += wrapped_dek_len
+    nonce = cipher_data[offset : offset + 12]
+    offset += 12
+    ciphertext = cipher_data[offset:]
+
+    crypto_client = cast(CryptographyClient, _get_azure_crypto_client())
+    dek = crypto_client.unwrap_key(KeyWrapAlgorithm.rsa_oaep_256, wrapped_dek).key
+
+    return AESGCM(dek).decrypt(nonce, ciphertext, None)
+
+
 def encrypt(plain_data: bytes) -> bytes:
     # Skip encryption in local environment (for development)
     if os.getenv("SERVER_ENVIRONMENT") == "local":
         return plain_data
+
+    if config.AZURE_KEY_ENCRYPTION_KEY_NAME:
+        return _azure_encrypt(plain_data)
 
     # TODO: ignore encryptor_header for now
     my_ciphertext, _ = client.encrypt(source=plain_data, keyring=_get_kms_keyring())
@@ -60,6 +122,9 @@ def decrypt(cipher_data: bytes) -> bytes:
     # Skip decryption in local environment (for development)
     if os.getenv("SERVER_ENVIRONMENT") == "local":
         return cipher_data
+
+    if config.AZURE_KEY_ENCRYPTION_KEY_NAME:
+        return _azure_decrypt(cipher_data)
 
     # TODO: ignore decryptor_header for now
     my_plaintext, _ = client.decrypt(source=cipher_data, keyring=_get_kms_keyring())

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
     "google-api-python-client>=2.167.0",
     "aws-encryption-sdk[mpl]>=4.0.1",
     "boto3>=1.37.36",
+    "azure-keyvault-keys>=4.9.0",
+    "azure-identity>=1.17.0",
+    "cryptography>=42.0.0",
     "aioboto3>=13.3.0",
     "rich>=13.9.4",
     "propelauth-fastapi>=4.2.6",
@@ -134,6 +137,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "e2b_code_interpreter"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "azure.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
Adds conditional support for Azure Key Vault as the encryption provider while keeping AWS KMS fully intact. When AZURE_KEY_ENCRYPTION_KEY_NAME is set, the server uses Azure Key Vault (envelope encryption: AES-256-GCM + RSA-OAEP-256 key wrapping); otherwise it falls back to the existing AWS KMS path. AWS config vars become optional (not required at startup) in Azure mode.

New env vars: AZURE_KEY_ENCRYPTION_KEY_NAME, AZURE_KEY_VAULT_URL
New deps: azure-keyvault-keys, azure-identity, cryptography

### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

[Describe your changes in detail (optional if the issue you linked already contains a
detail description of the change)]

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
