### PR TITLE
feat: add Azure Key Vault CSI support for DB password in utils

### DIFF
--- a/backend/aci/common/utils.py
+++ b/backend/aci/common/utils.py
@@ -27,7 +27,11 @@ _db_url_cache: str | None = None
 
 
 def get_db_password_sync() -> str:
-    """Fetches the DB password from AWS Secrets Manager synchronously."""
+    """Returns the DB password — from an env var on Azure (Key Vault CSI injection),
+    or from AWS Secrets Manager on AWS."""
+    if os.getenv("CLOUD_PLATFORM") == "azure":
+        return check_and_get_env_variable("SERVER_DB_PASSWORD")
+
     secret_name = check_and_get_env_variable("DB_SECRET_NAME")
     region_name = check_and_get_env_variable("AWS_REGION_NAME")
 
@@ -38,7 +42,11 @@ def get_db_password_sync() -> str:
 
 
 async def get_db_password() -> str:
-    """Fetches the DB password from AWS Secrets Manager asynchronously."""
+    """Returns the DB password — from an env var on Azure (Key Vault CSI injection),
+    or from AWS Secrets Manager on AWS."""
+    if os.getenv("CLOUD_PLATFORM") == "azure":
+        return check_and_get_env_variable("SERVER_DB_PASSWORD")
+
     secret_name = check_and_get_env_variable("DB_SECRET_NAME")
     region_name = check_and_get_env_variable("AWS_REGION_NAME")
 


### PR DESCRIPTION
Both get_db_password() and get_db_password_sync() now check CLOUD_PLATFORM first: on Azure the password is already injected as SERVER_DB_PASSWORD via Key Vault CSI, so no Secrets Manager call is needed. AWS path is unchanged.

### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

[Describe your changes in detail (optional if the issue you linked already contains a
detail description of the change)]

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
